### PR TITLE
bump to esri leaflet 2.0.0-beta.8 cdn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esri-leaflet-doc",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "author": "Patrick Arlt <parlt@esri.com> (http://patrickarlt.com)",
   "contributors": [
     "Patrick Arlt <parlt@esri.com> (http://patrickarlt.com)",

--- a/src/layouts/example.hbs
+++ b/src/layouts/example.hbs
@@ -21,11 +21,11 @@ layout: page.hbs
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
 
   <!-- Load Leaflet from CDN-->
-  <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v1.0.0-beta.2/leaflet.css" />
-  <script src="http://cdn.leafletjs.com/leaflet/v1.0.0-beta.2/leaflet.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1.0.0-beta.2/leaflet.css" />
+  <script src="https://cdn.jsdelivr.net/leaflet/1.0.0-beta.2/leaflet.js"></script>
 
   <!-- Load Esri Leaflet from CDN -->
-  <script src="//cdn.jsdelivr.net/leaflet.esri/{{package.version}}/esri-leaflet.js"></script>
+  <script src="https://cdn.jsdelivr.net/leaflet.esri/{{package.version}}/esri-leaflet.js"></script>
 
   <style>
     body { margin:0; padding:0; }

--- a/src/pages/api-reference/layers/dynamic-map-layer.md
+++ b/src/pages/api-reference/layers/dynamic-map-layer.md
@@ -172,7 +172,7 @@ dynamicMapLayer.bindPopup(
             <td>
                 Returns a new <a href="{{assets}}/api-reference/tasks/identify-features.html"><code>L.esri.services.IdentifyFeatures</code></a> object that can be used to identify features on this layer. Your callback function will be passed a <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">GeoJSON FeatureCollection</a> with the results or an error.
 <pre class="js"><code>dynamicMapLayer.identify()
-  .at(latlng, latlngbounds, 5)
+  .at(latlng)
   .run(function(error, featureCollection){
     console.log(featureCollection);
   });</code></pre>

--- a/src/pages/examples/center-map-on-address.hbs
+++ b/src/pages/examples/center-map-on-address.hbs
@@ -4,8 +4,8 @@ description: Geocode an address and then center the map on it automatically. Thi
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="//cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.css">
-<script src="//cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.css">
+<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.js"></script>
 
 <div id="map"></div>
 
@@ -14,7 +14,7 @@ layout: example.hbs
 
   var map = L.map('map');
 
-  L.tileLayer('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; <a href="//osm.org/copyright">OpenStreetMap</a> contributors'
   }).addTo(map);
 

--- a/src/pages/examples/clustering-feature-layers.hbs
+++ b/src/pages/examples/clustering-feature-layers.hbs
@@ -7,10 +7,10 @@ layout: example.hbs
 <!-- Include Leaflet.markercluster via rawgit.com, do not use in production -->
 <link rel="stylesheet" type="text/css" href="//cdn.rawgit.com/Leaflet/Leaflet.markercluster/v1.0.0-beta.2.0/dist/MarkerCluster.Default.css">
 <link rel="stylesheet" type="text/css" href="//cdn.rawgit.com/Leaflet/Leaflet.markercluster/v1.0.0-beta.2.0/dist/MarkerCluster.css">
-<script src="//cdn.rawgit.com/Leaflet/Leaflet.markercluster/v1.0.0-beta.2.0/dist/leaflet.markercluster.js"></script>
+<script src="https://cdn.rawgit.com/Leaflet/Leaflet.markercluster/v1.0.0-beta.2.0/dist/leaflet.markercluster.js"></script>
 
 <!-- Load Clustered Feature Layer from CDN -->
-<script src="//cdn.jsdelivr.net/leaflet.esri.clustered-feature-layer/2.0.0-beta.1/esri-leaflet-clustered-feature-layer.js"></script>
+<script src="https://cdn.jsdelivr.net/leaflet.esri.clustered-feature-layer/2.0.0-beta.1/esri-leaflet-clustered-feature-layer.js"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/geocoding-control.hbs
+++ b/src/pages/examples/geocoding-control.hbs
@@ -4,15 +4,15 @@ description: Using the geocoding control to search for addresses and center the 
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="//cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.css">
-<script src="//cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.css">
+<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.js"></script>
 
 <div id="map"></div>
 
 <script>
   var map = L.map('map').setView([40.91, -96.63], 4);
 
-  L.tileLayer('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
   }).addTo(map);
 

--- a/src/pages/examples/identifying-features.hbs
+++ b/src/pages/examples/identifying-features.hbs
@@ -21,15 +21,15 @@ layout: example.hbs
 
 <div id="map"></div>
 <div id="selectedFeatures" class="leaflet-bar map-text">Click on a
-  <a href="https://www.arcgis.com/home/item.html?id=3fcf06963b134254b73dccfbc1546eb9">NOAA weather advisory</a>
+  <a href="https://tmservices1.esri.com/arcgis/rest/services/LiveFeeds/Earthquakes/MapServer">USGS</a> earthquake.
 </div>
 <script>
   var map = L.map('map').setView([38.5, -96.8], 4);
 
   L.esri.basemapLayer('Gray').addTo(map);
 
-  var weatherStations = L.esri.dynamicMapLayer({
-    url: '//maps1.arcgisonline.com/ArcGIS/rest/services/NWS_Weather_Stations/MapServer',
+  var earthquakes = L.esri.dynamicMapLayer({
+    url: 'https://tmservices1.esri.com/arcgis/rest/services/LiveFeeds/Earthquakes/MapServer',
     opacity: 0.5,
     useCors: false
   }).addTo(map);
@@ -42,11 +42,11 @@ layout: example.hbs
     if(identifiedFeature){
       map.removeLayer(identifiedFeature);
     }
-    weatherStations.identify().on(map).at(e.latlng).run(function(error, featureCollection){
+    earthquakes.identify().on(map).at(e.latlng).run(function(error, featureCollection){
       console.log(featureCollection.features[0]);
       if (featureCollection.features.length > 0) {
         identifiedFeature = L.geoJson(featureCollection.features[0]).addTo(map);
-        pane.innerHTML = featureCollection.features[0].properties.Station_Na;
+        pane.innerHTML = "magnitude: " + featureCollection.features[0].properties.MAGNITUDE;
       }
       else {
         pane.innerHTML = 'No features identified.';

--- a/src/pages/examples/layer-ordering.hbs
+++ b/src/pages/examples/layer-ordering.hbs
@@ -11,8 +11,8 @@ layout: example.hbs
 
   L.esri.basemapLayer("Topographic").addTo(map);
 
-  var neighborhoodsUrl = "//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Neighborhoods_pdx/FeatureServer/0";
-  var eliotFootprintsUrl = "//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Eliot%20Building%20Footprints/FeatureServer/0"
+  var neighborhoodsUrl = "https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Neighborhoods_pdx/FeatureServer/0";
+  var eliotFootprintsUrl = "https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Eliot%20Building%20Footprints/FeatureServer/0"
 
   // create a map pane for neighborhoods
   map.createPane('neighborhoods');
@@ -25,7 +25,7 @@ layout: example.hbs
 
   // Panes are added to the map in order - this pane will be sit on top of 'neighborhoods'
   map.createPane('footprints');
-  
+
   L.esri.featureLayer({
     url: eliotFootprintsUrl,
     pane: 'footprints',

--- a/src/pages/examples/query-no-map.hbs
+++ b/src/pages/examples/query-no-map.hbs
@@ -15,26 +15,26 @@ layout: example.hbs
 
 <script>
   document.getElementById('map').style.height = '100px';
-  
+
   // no need to display, but lets use a map to ask user for HTML5 location
   var map = L.map('invisibleMap');
   map.locate();
-  
+
   map.on("locationfound", function(e) {
-    // use location to find out which census block they're inside.
+    // use location to find out which census block they are inside.
     L.esri.query({
-	  url: "//sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/1"
+	  url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/1"
 	}).intersects(e.latlng).run(function(error, censusBlocks){
 	    // if we find a match dig into the feature attributes to retrive median age
 	    if (censusBlocks.features.length > 0) {
-	      document.getElementById('message').innerHTML = 
-	        'the median age in the census block where you are currently located is <b>' + censusBlocks.features[0].properties.MED_AGE + 
+	      document.getElementById('message').innerHTML =
+	        'the median age of the census block where you are currently located is <b>' + censusBlocks.features[0].properties.MED_AGE +
 	        '</b> years old';
 	    }
 	    // otherwise, fail gracefully
 	    else {
-	      document.getElementById('message').innerHTML = 
-	        'either you arent in the United States or you prefer not to say.'; 
+	      document.getElementById('message').innerHTML =
+	        'either you arent currently in the United States or you prefer not to say.';
 	    }
 	  });
   });

--- a/src/pages/examples/reverse-geocoding.hbs
+++ b/src/pages/examples/reverse-geocoding.hbs
@@ -4,15 +4,15 @@ description: Query the closest address to a given point with the Esri Leaflet Ge
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="//cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.css">
-<script src="//cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.css">
+<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.js"></script>
 
 <div id="map"></div>
 
 <script>
   var map = L.map('map').setView([40.702, -73.979], 13);
 
-  L.tileLayer('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
   }).addTo(map);
 

--- a/src/pages/examples/search-feature-layer.hbs
+++ b/src/pages/examples/search-feature-layer.hbs
@@ -4,15 +4,15 @@ description: Searches features layers for matching text in addition to geocoding
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="//cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.css">
-<script src="//cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.css">
+<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.js"></script>
 
 <div id="map"></div>
 
 <script>
   var map = L.map('map').setView([40.91, -96.63], 4);
 
-  L.tileLayer('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
   }).addTo(map);
 
@@ -22,7 +22,7 @@ layout: example.hbs
     providers: [
       arcgisOnline,
       new L.esri.Geocoding.FeatureLayerProvider({
-        url: '//services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/gisday/FeatureServer/0/',
+        url: 'https://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/gisday/FeatureServer/0/',
         searchFields: ['Name', 'Organization'],
         label: 'GIS Day Events',
         bufferRadius: 5000,

--- a/src/pages/examples/search-map-service.hbs
+++ b/src/pages/examples/search-map-service.hbs
@@ -4,15 +4,15 @@ description: Searches map services for matching text in addition to geocoding. T
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="//cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.css">
-<script src="//cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.css">
+<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.0.2/esri-leaflet-geocoder.js"></script>
 
 <div id="map"></div>
 
 <script>
   var map = L.map('map').setView([40.91, -96.63], 4);
 
-  L.tileLayer('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
   }).addTo(map);
 
@@ -23,7 +23,7 @@ layout: example.hbs
       arcgisOnline,
       new L.esri.Geocoding.MapServiceProvider({
         label: 'States and Counties',
-        url: '//sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer',
+        url: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer',
         layers: [2, 3],
         searchFields: ['NAME', 'STATE_NAME']
       })

--- a/src/pages/examples/simple-dynamic-map-layer.hbs
+++ b/src/pages/examples/simple-dynamic-map-layer.hbs
@@ -12,7 +12,8 @@ layout: example.hbs
   L.esri.basemapLayer('Gray').addTo(map);
 
   L.esri.dynamicMapLayer({
-    url: '//server.arcgisonline.com/ArcGIS/rest/services/Specialty/Soil_Survey_Map/MapServer',
-    opacity: 0.5
+    url: 'https://tmservices1.esri.com/arcgis/rest/services/LiveFeeds/Earthquakes/MapServer',
+    opacity: 0.5,
+    useCors: false
   }).addTo(map);
 </script>

--- a/src/pages/examples/styling-clusters.hbs
+++ b/src/pages/examples/styling-clusters.hbs
@@ -7,10 +7,10 @@ layout: example.hbs
 <!-- Include Leaflet.markercluster via rawgit.com, do not use in production -->
 <link rel="stylesheet" type="text/css" href="//cdn.rawgit.com/Leaflet/Leaflet.markercluster/v1.0.0-beta.2.0/dist/MarkerCluster.Default.css">
 <link rel="stylesheet" type="text/css" href="//cdn.rawgit.com/Leaflet/Leaflet.markercluster/v1.0.0-beta.2.0/dist/MarkerCluster.css">
-<script src="//cdn.rawgit.com/Leaflet/Leaflet.markercluster/v1.0.0-beta.2.0/dist/leaflet.markercluster.js"></script>
+<script src="https://cdn.rawgit.com/Leaflet/Leaflet.markercluster/v1.0.0-beta.2.0/dist/leaflet.markercluster.js"></script>
 
 <!-- Load Clustered Feature Layer from CDN -->
-<script src="//cdn.jsdelivr.net/leaflet.esri.clustered-feature-layer/2.0.0-beta.1/esri-leaflet-clustered-feature-layer.js"></script>
+<script src="https://cdn.jsdelivr.net/leaflet.esri.clustered-feature-layer/2.0.0-beta.1/esri-leaflet-clustered-feature-layer.js"></script>
 
 <style>
   .cluster {
@@ -97,29 +97,29 @@ layout: example.hbs
   // Define some icons that represent our bus stops
   var icons = {
     north: L.icon({
-      iconUrl: '//esri.github.io/esri-leaflet/img/bus-stop-north.png',
-      iconRetinaUrl: '//esri.github.io/esri-leaflet/img/bus-stop-north@2x.png',
+      iconUrl: 'https://esri.github.io/esri-leaflet/img/bus-stop-north.png',
+      iconRetinaUrl: 'https://esri.github.io/esri-leaflet/img/bus-stop-north@2x.png',
       iconSize: [27, 31],
       iconAnchor: [13.5, 17.5],
       popupAnchor: [0, -11],
     }),
     south: L.icon({
-      iconUrl: '//esri.github.io/esri-leaflet/img/bus-stop-south.png',
-      iconRetinaUrl: '//esri.github.io/esri-leaflet/img/bus-stop-south@2x.png',
+      iconUrl: 'https://esri.github.io/esri-leaflet/img/bus-stop-south.png',
+      iconRetinaUrl: 'https://esri.github.io/esri-leaflet/img/bus-stop-south@2x.png',
       iconSize: [27, 31],
       iconAnchor: [13.5, 13.5],
       popupAnchor: [0, -11],
     }),
     east: L.icon({
-      iconUrl: '//esri.github.io/esri-leaflet/img/bus-stop-east.png',
-      iconRetinaUrl: '//esri.github.io/esri-leaflet/img/bus-stop-east@2x.png',
+      iconUrl: 'https://esri.github.io/esri-leaflet/img/bus-stop-east.png',
+      iconRetinaUrl: 'https://esri.github.io/esri-leaflet/img/bus-stop-east@2x.png',
       iconSize: [31, 27],
       iconAnchor: [13.5, 17.5],
       popupAnchor: [0, -11],
     }),
     west: L.icon({
-      iconUrl: '//esri.github.io/esri-leaflet/img/bus-stop-west.png',
-      iconRetinaUrl: '//esri.github.io/esri-leaflet/img/bus-stop-west@2x.png',
+      iconUrl: 'https://esri.github.io/esri-leaflet/img/bus-stop-west.png',
+      iconRetinaUrl: 'https://esri.github.io/esri-leaflet/img/bus-stop-west@2x.png',
       iconSize: [31, 27],
       iconAnchor: [17.5, 13.5],
       popupAnchor: [0, -11],

--- a/src/pages/examples/tile-layer-1.hbs
+++ b/src/pages/examples/tile-layer-1.hbs
@@ -10,6 +10,6 @@ layout: example.hbs
   var map = L.map('map').setView([ 30.70, -81.47], 12);
 
   L.esri.tiledMapLayer({
-    url: "//services.arcgisonline.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer"
+    url: "https://services.arcgisonline.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer"
   }).addTo(map);
 </script>

--- a/src/pages/examples/tile-layer-2.hbs
+++ b/src/pages/examples/tile-layer-2.hbs
@@ -10,7 +10,7 @@ layout: example.hbs
   var map = L.map('map').setView([19.31, -155.04], 9);
 
   L.esri.tiledMapLayer({
-    url: "//services.arcgisonline.com/ArcGIS/rest/services/Specialty/World_Navigation_Charts/MapServer",
+    url: "https://services.arcgisonline.com/ArcGIS/rest/services/Specialty/World_Navigation_Charts/MapServer",
     detectRetina: false,
     minZoom: 3,
     maxZoom: 10

--- a/src/pages/tutorials/using-with-requirejs.md
+++ b/src/pages/tutorials/using-with-requirejs.md
@@ -1,6 +1,6 @@
 ---
-title: Esri Leaflet + Require JS
-description: How to use Esri Leaflet with Require JS.
+title: Esri Leaflet + RequireJS
+description: How to use Esri Leaflet with RequireJS.
 layout: tutorials.hbs
 ---
 

--- a/src/partials/header.hbs
+++ b/src/partials/header.hbs
@@ -32,18 +32,19 @@
   <!-- stylesheet -->
   <link rel="stylesheet" href="{{assets}}css/style.css">
 
-  <!-- leaflet -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-beta.2/leaflet.css" />
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-beta.2/leaflet.js"></script>
+  <!-- Load Leaflet from CDN-->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1.0.0-beta.2/leaflet.css" />
+  <script src="https://cdn.jsdelivr.net/leaflet/1.0.0-beta.2/leaflet.js"></script>
 
-  <script src="//cdn.jsdelivr.net/leaflet.esri/2.0.0-beta.7/esri-leaflet.js"></script>
-  <script src="//cdn.jsdelivr.net/jsdelivr-rum/latest/jsdelivr-rum.min.js"></script>
+  <!-- Load Esri Leaflet from CDN -->
+  <script src="https://cdn.jsdelivr.net/leaflet.esri/{{package.version}}/esri-leaflet.js"></script>
+  <script src="https://cdn.jsdelivr.net/jsdelivr-rum/latest/jsdelivr-rum.min.js"></script>
 
   {{#if siteData.isDev}}
     <!-- 'livereload' for development -->
     <script src="//localhost:35729/livereload.js"></script>
   {{else}}
-    
+
   {{/if}}
 
   <!-- Google Analytics -->


### PR DESCRIPTION
resolves #14, Esri/esri-leaflet#750

waiting for `2.0.0-beta.8` to appear on the [CDN](https://github.com/jsdelivr/jsdelivr/pull/10203#issuecomment-191359101) before merging and pushing the changes to the live site