### PR TITLE
bumping examples to use leaflet 1.0.0-rc.1

### DIFF
--- a/src/layouts/example.hbs
+++ b/src/layouts/example.hbs
@@ -21,8 +21,8 @@ layout: page.hbs
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
 
   <!-- Load Leaflet from CDN-->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1.0.0-beta.2/leaflet.css" />
-  <script src="https://cdn.jsdelivr.net/leaflet/1.0.0-beta.2/leaflet.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1.0.0-rc.1/leaflet.css" />
+  <script src="https://cdn.jsdelivr.net/leaflet/1.0.0-rc.1/leaflet-src.js"></script>
 
   <!-- Load Esri Leaflet from CDN -->
   <script src="https://cdn.jsdelivr.net/leaflet.esri/{{package.version}}/esri-leaflet.js"></script>

--- a/src/pages/examples/clustering-feature-layers.hbs
+++ b/src/pages/examples/clustering-feature-layers.hbs
@@ -4,9 +4,10 @@ description: Visualize dense services as clusters of points with the <a href="ht
 layout: example.hbs
 ---
 
-<!-- Include Leaflet.markercluster via rawgit.com, do not use in production -->
-<link rel="stylesheet" type="text/css" href="//cdn.rawgit.com/Leaflet/Leaflet.markercluster/v1.0.0-beta.2.0/dist/MarkerCluster.Default.css">
-<link rel="stylesheet" type="text/css" href="//cdn.rawgit.com/Leaflet/Leaflet.markercluster/v1.0.0-beta.2.0/dist/MarkerCluster.css">
+<!-- Include Leaflet.markercluster via rawgit.com
+in production you'd be better off hosting these libraries yourself -->
+<link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/Leaflet/Leaflet.markercluster/v1.0.0-beta.2.0/dist/MarkerCluster.Default.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/Leaflet/Leaflet.markercluster/v1.0.0-beta.2.0/dist/MarkerCluster.css">
 <script src="https://cdn.rawgit.com/Leaflet/Leaflet.markercluster/v1.0.0-beta.2.0/dist/leaflet.markercluster.js"></script>
 
 <!-- Load Clustered Feature Layer from CDN -->

--- a/src/pages/examples/feature-layer-snapshot.hbs
+++ b/src/pages/examples/feature-layer-snapshot.hbs
@@ -11,8 +11,8 @@ layout: example.hbs
 
   L.esri.basemapLayer("Topographic").addTo(map);
 
-  var neighborhoodsUrl = "//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Neighborhoods_pdx/FeatureServer/0";
-  var bikeParkingUrl = "//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Portland_Bicycle_Parking/FeatureServer/0";
+  var neighborhoodsUrl = "https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Neighborhoods_pdx/FeatureServer/0";
+  var bikeParkingUrl = "https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Portland_Bicycle_Parking/FeatureServer/0";
 
   // query a feature service for a neighborhood
   L.esri.query({

--- a/src/pages/examples/gp-plugin.hbs
+++ b/src/pages/examples/gp-plugin.hbs
@@ -4,7 +4,7 @@ description: This demo relies on the <a href="https://github.com/jgravois/esri-l
 layout: example.hbs
 ---
 
-<script src="//cdn.jsdelivr.net/leaflet.esri.gp/2.0.0/esri-leaflet-gp.js"></script>
+<script src="https://cdn.jsdelivr.net/leaflet.esri.gp/2.0.0/esri-leaflet-gp.js"></script>
 
 <style>
   #info-pane {
@@ -30,7 +30,7 @@ layout: example.hbs
   L.esri.basemapLayer('Gray').addTo(map);
 
   var gpService = L.esri.GP.service({
-    url: "//sampleserver1.arcgisonline.com/ArcGIS/rest/services/Network/ESRI_DriveTime_US/GPServer/CreateDriveTimePolygons",
+    url: "https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Network/ESRI_DriveTime_US/GPServer/CreateDriveTimePolygons",
     useCors:false
   });
 

--- a/src/pages/examples/imagery-popups.hbs
+++ b/src/pages/examples/imagery-popups.hbs
@@ -12,7 +12,7 @@ layout: example.hbs
   L.esri.basemapLayer('Gray').addTo(map);
 
   var landsatImagery = L.esri.imageMapLayer({
-    url: '//sampleserver3.arcgisonline.com/ArcGIS/rest/services/Portland/CascadeLandsat/ImageServer',
+    url: 'https://sampleserver3.arcgisonline.com/ArcGIS/rest/services/Portland/CascadeLandsat/ImageServer',
     useCors: false
   }).addTo(map);
 

--- a/src/pages/examples/non-mercator-projection-2.hbs
+++ b/src/pages/examples/non-mercator-projection-2.hbs
@@ -4,16 +4,19 @@ description: Using non mercator tiles with <code>L.esri.TiledMapLayer</code> wit
 layout: example.hbs
 ---
 
+<!-- Include Proj4JS via rawgit.com
+in production you'd be better off hosting these libraries yourself -->
 <script src="//rawgit.com/proj4js/proj4js/2.3.12/dist/proj4-src.js"></script>
 <script src="//rawgit.com/kartena/Proj4Leaflet/1.0.0-beta.1/src/proj4leaflet.js"></script>
 
 <div id="map"></div>
 
 <script>
-  // create new Proj4Leaflet CRS:
-  // 1. Proj4 and WKT definitions can be found at sites like http://epsg.io, http://spatialreference.org/ or by using gdalsrsinfo http://www.gdal.org/gdalsrsinfo.html
-  // 2. Appropriate values to supply to the resolution and origin constructor options can be found in the ArcGIS Server RESTful tile server endpoint (ex: http://mapserv.utah.gov/arcgis/rest/services/BaseMaps/Terrain/MapServer)
-  // 3. The numeric code within the first parameter (ex: `2193`) will be used to project the dynamic map layer on the fly
+  /* create new Proj4Leaflet CRS:
+  1. Proj4 and WKT definitions can be found at sites like http://epsg.io, http://spatialreference.org/ or by using gdalsrsinfo http://www.gdal.org/gdalsrsinfo.html
+  2. Appropriate values to supply to the resolution and origin constructor options can be found in the ArcGIS Server RESTful tile server endpoint (ex: http://mapserv.utah.gov/arcgis/rest/services/BaseMaps/Terrain/MapServer)
+  3. The numeric code within the first parameter (ex: `2193`) will be used to project the dynamic map layer on the fly
+  */
   var crs = new L.Proj.CRS('ESRI:2193', '+proj=tmerc +lat_0=0 +lon_0=173 +k=0.9996 +x_0=1600000 +y_0=10000000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs ', {
     origin: [-4020900, 19998100],
     resolutions: [

--- a/src/pages/examples/non-mercator-projection.hbs
+++ b/src/pages/examples/non-mercator-projection.hbs
@@ -4,16 +4,19 @@ description: Using non mercator tiles with <code>L.esri.TiledMapLayer</code> wit
 layout: example.hbs
 ---
 
-<script src="//rawgit.com/proj4js/proj4js/2.3.12/dist/proj4-src.js"></script>
-<script src="//rawgit.com/kartena/Proj4Leaflet/1.0.0-beta.1/src/proj4leaflet.js"></script>
+<!-- Include Proj4JS via rawgit.com
+in production you'd be better off hosting these libraries yourself -->
+<script src="https://rawgit.com/proj4js/proj4js/2.3.12/dist/proj4-src.js"></script>
+<script src="https://rawgit.com/kartena/Proj4Leaflet/1.0.0-beta.1/src/proj4leaflet.js"></script>
 
 <div id="map"></div>
 
 <script>
-  // create new Proj4Leaflet CRS:
-  // 1. Proj4 and WKT definitions can be found at sites like http://epsg.io, http://spatialreference.org/ or by using gdalsrsinfo http://www.gdal.org/gdalsrsinfo.html
-  // 2. Appropriate values to supply to the resolution and origin constructor options can be found in the ArcGIS Server RESTful tile server endpoint (ex: http://mapserv.utah.gov/arcgis/rest/services/BaseMaps/Terrain/MapServer)
-  // 3. The numeric code within the first parameter (ex: `26912`) will be used to project the dynamic map layer on the fly
+  /* create new Proj4Leaflet CRS:
+  1. Proj4 and WKT definitions can be found at sites like http://epsg.io, http://spatialreference.org/ or by using gdalsrsinfo http://www.gdal.org/gdalsrsinfo.html
+  2. Appropriate values to supply to the resolution and origin constructor options can be found in the ArcGIS Server RESTful tile server endpoint (ex: http://mapserv.utah.gov/arcgis/rest/services/BaseMaps/Terrain/MapServer)
+  3. The numeric code within the first parameter (ex: `26912`) will be used to project the dynamic map layer on the fly
+  */
   var crs = new L.Proj.CRS('EPSG:26912', '+proj=utm +zone=12 +ellps=GRS80 +datum=NAD83 +units=m +no_defs', {
     origin: [-5120900, 9998100],
     resolutions: [

--- a/src/pages/examples/parse-feature-collection.hbs
+++ b/src/pages/examples/parse-feature-collection.hbs
@@ -11,7 +11,7 @@ layout: example.hbs
 
   L.esri.basemapLayer('Topographic').addTo(map);
 
-  L.esri.get('//www.arcgis.com/sharing/content/items/62914b2820c24d4e95710ebae77937cb/data', {}, function (error, response) {
+  L.esri.get('https://www.arcgis.com/sharing/content/items/62914b2820c24d4e95710ebae77937cb/data', {}, function (error, response) {
     var features = response.operationalLayers[0].featureCollection.layers[0].featureSet.features;
     var idField = response.operationalLayers[0].featureCollection.layers[0].layerDefinition.objectIdField;
 
@@ -23,7 +23,7 @@ layout: example.hbs
 
     for (var i = features.length - 1; i >= 0; i--) {
       // convert ArcGIS Feature to GeoJSON Feature
-      var feature = L.esri.Util.arcgisToGeojson(features[i], idField);
+      var feature = L.esri.Util.arcgisToGeoJSON(features[i], idField);
 
       // unproject the web mercator coordinates to lat/lng
       var latlng = L.Projection.Mercator.unproject(L.point(feature.geometry.coordinates));

--- a/src/pages/examples/query-no-map.hbs
+++ b/src/pages/examples/query-no-map.hbs
@@ -14,6 +14,11 @@ layout: example.hbs
 <div id="invisibleMap"></div>
 
 <script>
+  // html5 geolocation requires a secure connection
+  if (window.location.host == 'esri.github.io' && window.location.protocol != "https:") {
+    window.location.protocol = "https";
+  }
+
   document.getElementById('map').style.height = '100px';
 
   // no need to display, but lets use a map to ask user for HTML5 location

--- a/src/pages/examples/reverse-geocoding.hbs
+++ b/src/pages/examples/reverse-geocoding.hbs
@@ -10,7 +10,7 @@ layout: example.hbs
 <div id="map"></div>
 
 <script>
-  var map = L.map('map').setView([40.702, -73.979], 13);
+  var map = L.map('map').setView([40.725, -73.985], 13);
 
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'

--- a/src/pages/examples/search-map-service.hbs
+++ b/src/pages/examples/search-map-service.hbs
@@ -1,6 +1,6 @@
 ---
 title: Searching map services
-description: Searches map services for matching text in addition to geocoding. This demo relies of the <a href="https://github.com/Esri/esri-leaflet-geocoder">Esri Leaflet Geocoder</a> plugin.
+description: In addition to geocoding addresses and points of interest, you can also search features in map services for matching text. This demo relies of the <a href="https://github.com/Esri/esri-leaflet-geocoder">Esri Leaflet Geocoder</a> plugin.
 layout: example.hbs
 ---
 

--- a/src/pages/examples/spatial-queries.hbs
+++ b/src/pages/examples/spatial-queries.hbs
@@ -39,7 +39,7 @@ layout: example.hbs
 
   // create our layer
   neighborhoods = L.esri.featureLayer({
-    url: "//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Neighborhoods_pdx/FeatureServer/0",
+    url: "https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Neighborhoods_pdx/FeatureServer/0",
     style: {
       color: 'gray',
       weight: 1

--- a/src/pages/examples/styling-clusters.hbs
+++ b/src/pages/examples/styling-clusters.hbs
@@ -4,9 +4,10 @@ description: Customizing the display of clusters and markers with <code>L.DivIco
 layout: example.hbs
 ---
 
-<!-- Include Leaflet.markercluster via rawgit.com, do not use in production -->
-<link rel="stylesheet" type="text/css" href="//cdn.rawgit.com/Leaflet/Leaflet.markercluster/v1.0.0-beta.2.0/dist/MarkerCluster.Default.css">
-<link rel="stylesheet" type="text/css" href="//cdn.rawgit.com/Leaflet/Leaflet.markercluster/v1.0.0-beta.2.0/dist/MarkerCluster.css">
+<!-- Include Leaflet.markercluster via rawgit.com
+in production you'd be better off hosting these libraries yourself -->
+<link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/Leaflet/Leaflet.markercluster/v1.0.0-beta.2.0/dist/MarkerCluster.Default.css">
+<link rel="stylesheet" type="text/css" href="http://cdn.rawgit.com/Leaflet/Leaflet.markercluster/v1.0.0-beta.2.0/dist/MarkerCluster.css">
 <script src="https://cdn.rawgit.com/Leaflet/Leaflet.markercluster/v1.0.0-beta.2.0/dist/leaflet.markercluster.js"></script>
 
 <!-- Load Clustered Feature Layer from CDN -->

--- a/src/pages/examples/styling-feature-layer-points.hbs
+++ b/src/pages/examples/styling-feature-layer-points.hbs
@@ -11,29 +11,29 @@ layout: example.hbs
 
   var icons = {
     north: L.icon({
-      iconUrl: '//esri.github.io/esri-leaflet/img/bus-stop-north.png',
-      iconRetinaUrl: '//esri.github.io/esri-leaflet/img/bus-stop-north@2x.png',
+      iconUrl: 'https://esri.github.io/esri-leaflet/img/bus-stop-north.png',
+      iconRetinaUrl: 'https://esri.github.io/esri-leaflet/img/bus-stop-north@2x.png',
       iconSize: [27, 31],
       iconAnchor: [13.5, 17.5],
       popupAnchor: [0, -11],
     }),
     south: L.icon({
-      iconUrl: '//esri.github.io/esri-leaflet/img/bus-stop-south.png',
-      iconRetinaUrl: '//esri.github.io/esri-leaflet/img/bus-stop-south@2x.png',
+      iconUrl: 'https://esri.github.io/esri-leaflet/img/bus-stop-south.png',
+      iconRetinaUrl: 'https://esri.github.io/esri-leaflet/img/bus-stop-south@2x.png',
       iconSize: [27, 31],
       iconAnchor: [13.5, 13.5],
       popupAnchor: [0, -11],
     }),
     east: L.icon({
-      iconUrl: '//esri.github.io/esri-leaflet/img/bus-stop-east.png',
-      iconRetinaUrl: '//esri.github.io/esri-leaflet/img/bus-stop-east@2x.png',
+      iconUrl: 'https://esri.github.io/esri-leaflet/img/bus-stop-east.png',
+      iconRetinaUrl: 'https://esri.github.io/esri-leaflet/img/bus-stop-east@2x.png',
       iconSize: [31, 27],
       iconAnchor: [13.5, 17.5],
       popupAnchor: [0, -11],
     }),
     west: L.icon({
-      iconUrl: '//esri.github.io/esri-leaflet/img/bus-stop-west.png',
-      iconRetinaUrl: '//esri.github.io/esri-leaflet/img/bus-stop-west@2x.png',
+      iconUrl: 'https://esri.github.io/esri-leaflet/img/bus-stop-west.png',
+      iconRetinaUrl: 'https://esri.github.io/esri-leaflet/img/bus-stop-west@2x.png',
       iconSize: [31, 27],
       iconAnchor: [17.5, 13.5],
       popupAnchor: [0, -11],

--- a/src/pages/examples/styling-heatmaps.hbs
+++ b/src/pages/examples/styling-heatmaps.hbs
@@ -4,11 +4,12 @@ description: Custom styling of heatmap gradients with the <code>L.heat</code> op
 layout: example.hbs
 ---
 
-<!-- Include Leaflet.heat via rawgit.com, do not use in production -->
-<script src="//rawgit.com/Leaflet/Leaflet.heat/gh-pages/dist/leaflet-heat.js"></script>
+<!-- Include Leaflet.heat via rawgit.com
+in production you'd be better off hosting this library yourself -->
+<script src="https://rawgit.com/Leaflet/Leaflet.heat/gh-pages/dist/leaflet-heat.js"></script>
 
 <!-- Load Heatmap Feature Layer from CDN -->
-<script src="//cdn.jsdelivr.net/leaflet.esri.heatmap-feature-layer/2.0.0-beta.1/esri-leaflet-heatmap-feature-layer.js"></script>
+<script src="https://cdn.jsdelivr.net/leaflet.esri.heatmap-feature-layer/2.0.0-beta.1/esri-leaflet-heatmap-feature-layer.js"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/visualize-points-as-a-heatmap.hbs
+++ b/src/pages/examples/visualize-points-as-a-heatmap.hbs
@@ -4,11 +4,13 @@ description: Displaying point data as a heatmap using the <code>L.heat</code> pl
 layout: example.hbs
 ---
 
-<!-- Include Leaflet.heat via rawgit.com, do not use in production -->
-<script src="//rawgit.com/Leaflet/Leaflet.heat/gh-pages/dist/leaflet-heat.js"></script>
+<!-- Include Leaflet.heat via rawgit.com
+in production you'd be better off hosting this library yourself -->
+
+<script src="https://rawgit.com/Leaflet/Leaflet.heat/gh-pages/dist/leaflet-heat.js"></script>
 
 <!-- Load Heatmap Feature Layer from CDN -->
-<script src="//cdn.jsdelivr.net/leaflet.esri.heatmap-feature-layer/2.0.0-beta.1/esri-leaflet-heatmap-feature-layer.js"></script>
+<script src="https://cdn.jsdelivr.net/leaflet.esri.heatmap-feature-layer/2.0.0-beta.1/esri-leaflet-heatmap-feature-layer.js"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/visualizing-time-on-dynamic-map-layer.hbs
+++ b/src/pages/examples/visualizing-time-on-dynamic-map-layer.hbs
@@ -58,7 +58,7 @@ layout: example.hbs
   L.esri.basemapLayer('GrayLabels').addTo(map);
 
   var oilWells = L.esri.dynamicMapLayer({
-    url: '//sampleserver3.arcgisonline.com/ArcGIS/rest/services/Petroleum/KSWells/MapServer',
+    url: 'https://sampleserver3.arcgisonline.com/ArcGIS/rest/services/Petroleum/KSWells/MapServer',
     useCors: false,
     layers: [0],
     // for some reason this service in particular sometimes redirects json requests to a bogus IP address

--- a/src/pages/examples/visualizing-time-with-feature-layer.hbs
+++ b/src/pages/examples/visualizing-time-with-feature-layer.hbs
@@ -4,11 +4,12 @@ description: Filtering a feature layer within a certain time range. Try dates be
 layout: example.hbs
 ---
 
-<!-- Include Leaflet.heat via rawgit.com, do not use in production -->
-<script src="//rawgit.com/Leaflet/Leaflet.heat/gh-pages/dist/leaflet-heat.js"></script>
+<!-- Include Leaflet.heat via rawgit.com
+in production you'd be better off hosting this library yourself -->
+<script src="https://rawgit.com/Leaflet/Leaflet.heat/gh-pages/dist/leaflet-heat.js"></script>
 
 <!-- Load Heatmap Feature Layer from CDN -->
-<script src="//cdn.jsdelivr.net/leaflet.esri.heatmap-feature-layer/2.0.0-beta.1/esri-leaflet-heatmap-feature-layer.js"></script>
+<script src="https://cdn.jsdelivr.net/leaflet.esri.heatmap-feature-layer/2.0.0-beta.1/esri-leaflet-heatmap-feature-layer.js"></script>
 
 <style>
   #time-ranges {

--- a/src/pages/examples/zooming-to-all-features-2.hbs
+++ b/src/pages/examples/zooming-to-all-features-2.hbs
@@ -14,7 +14,7 @@ layout: example.hbs
 
   // add a graphic layer composed of selected US Counties
   var fl = L.esri.featureLayer({
-    url: '//sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/2',
+    url: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/2',
     where: "NAME='Los Angeles' OR NAME='San Bernardino'"
   }).addTo(map);
 

--- a/src/partials/header.hbs
+++ b/src/partials/header.hbs
@@ -33,8 +33,8 @@
   <link rel="stylesheet" href="{{assets}}css/style.css">
 
   <!-- Load Leaflet from CDN-->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1.0.0-beta.2/leaflet.css" />
-  <script src="https://cdn.jsdelivr.net/leaflet/1.0.0-beta.2/leaflet.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1.0.0-rc.1/leaflet.css" />
+  <script src="https://cdn.jsdelivr.net/leaflet/1.0.0-rc.1/leaflet-src.js"></script>
 
   <!-- Load Esri Leaflet from CDN -->
   <script src="https://cdn.jsdelivr.net/leaflet.esri/{{package.version}}/esri-leaflet.js"></script>


### PR DESCRIPTION
* bumped to `1.0.0-rc.1` and confirmed all samples are functioning
* fixed a bug in the [Parsing Feature Collections](http://esri.github.io/esri-leaflet/examples/parse-feature-collection.html) sample that was induced by an [uncaught](https://github.com/Esri/esri-leaflet/commit/f6e9f4f0503bb204f6d187431e7551a6127c0b66) breaking change
* move more links to use `https` explicitly
* force https in [Query No Map](http://esri.github.io/esri-leaflet/examples/query-no-map.html) sample, since Chrome 50 [requires SSL](https://blogs.esri.com/esri/arcgis/2016/04/14/increased-web-api-security-in-google-chrome/) when leveraging the Geolocation API.
* based on hackerlab feedback, added more code comments to clarify what users *should* do when we tell them not to point at raw.git in production