### PR TITLE
bump to 2.0.0 and fix broken samples

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "esri-leaflet-doc",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0",
+  "private": true,
   "author": "Patrick Arlt <parlt@esri.com> (http://patrickarlt.com)",
   "contributors": [
     "Patrick Arlt <parlt@esri.com> (http://patrickarlt.com)",

--- a/src/pages/examples/arcgis-online-auth.hbs
+++ b/src/pages/examples/arcgis-online-auth.hbs
@@ -1,6 +1,6 @@
 ---
 title: ArcGIS Online OAuth
-description: Authenticate ArcGIS Online users with OAuth 2.0 to access user information, private resources and premium services.
+description: Allow ArcGIS Online users to sign in with OAuth 2.0 to access their own information, private resources and premium services.
 layout: example.hbs
 ---
 
@@ -67,6 +67,5 @@ layout: example.hbs
 
   // make a new map and basemap
   var map = L.map('map').setView([39.36, -96.19], 4);
-
   L.esri.basemapLayer('Gray').addTo(map);
 </script>

--- a/src/pages/examples/arcgis-server-auth.hbs
+++ b/src/pages/examples/arcgis-server-auth.hbs
@@ -7,8 +7,12 @@ layout: example.hbs
 <div id="map"></div>
 
 <script>
-  var map = L.map('map').setView([34.326, -117.697], 12);
+  // workaround for old ie
+  if (!window.location.origin) {
+    window.location.origin = window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '');
+  }
 
+  var map = L.map('map').setView([34.326, -117.697], 12);
   L.esri.basemapLayer('Topographic').addTo(map);
 
   function serverAuth(callback){

--- a/src/pages/examples/customizing-popups.hbs
+++ b/src/pages/examples/customizing-popups.hbs
@@ -8,11 +8,10 @@ layout: example.hbs
 
 <script>
   var map = L.map('map').setView([38.5, -96.8], 4);
-
   L.esri.basemapLayer('Gray').addTo(map);
 
   var wildfireRisk = L.esri.dynamicMapLayer({
-    url: '//maps7.arcgisonline.com/arcgis/rest/services/USDA_USFS_2014_Wildfire_Hazard_Potential/MapServer'
+    url: 'https://maps7.arcgisonline.com/arcgis/rest/services/USDA_USFS_2014_Wildfire_Hazard_Potential/MapServer'
   }).addTo(map);
 
   wildfireRisk.bindPopup(function (error, featureCollection) {

--- a/src/pages/examples/identifying-features.hbs
+++ b/src/pages/examples/identifying-features.hbs
@@ -46,7 +46,9 @@ layout: example.hbs
       console.log(featureCollection.features[0]);
       if (featureCollection.features.length > 0) {
         identifiedFeature = L.geoJson(featureCollection.features[0]).addTo(map);
-        pane.innerHTML = "magnitude: " + featureCollection.features[0].properties.MAGNITUDE;
+        // string to number to string = trimmed zeros.  the wonders of JavaScript
+        var magTrimmed = parseFloat(featureCollection.features[0].properties.MAGNITUDE).toString();
+        pane.innerHTML = "magnitude: " + magTrimmed;
       }
       else {
         pane.innerHTML = 'No features identified.';

--- a/src/pages/examples/imagery-popups.hbs
+++ b/src/pages/examples/imagery-popups.hbs
@@ -8,7 +8,6 @@ layout: example.hbs
 
 <script>
   var map = L.map('map').setView([45.358651, -121.691067], 9);
-
   L.esri.basemapLayer('Gray').addTo(map);
 
   var landsatImagery = L.esri.imageMapLayer({

--- a/src/pages/examples/parse-feature-collection.hbs
+++ b/src/pages/examples/parse-feature-collection.hbs
@@ -8,7 +8,6 @@ layout: example.hbs
 
 <script>
   var map = L.map('map');
-
   L.esri.basemapLayer('Topographic').addTo(map);
 
   L.esri.get('https://www.arcgis.com/sharing/content/items/62914b2820c24d4e95710ebae77937cb/data', {}, function (error, response) {
@@ -33,7 +32,6 @@ layout: example.hbs
     }
 
     var geojson = L.geoJson(featureCollection).addTo(map);
-
     map.fitBounds(geojson.getBounds());
   });
 </script>

--- a/src/pages/examples/simplifying-complex-features.hbs
+++ b/src/pages/examples/simplifying-complex-features.hbs
@@ -45,7 +45,6 @@ layout: example.hbs
   zipcodes.on('mouseover', function(e){
     oldId = e.layer.feature.id;
     document.getElementById('info-pane').innerHTML = e.layer.feature.properties.ZIP + ' ' + e.layer.feature.properties.PO_NAME;
-    e.layer.bringToFront();
     zipcodes.setFeatureStyle(e.layer.feature.id, {
       color: '#9D78D2',
       weight: 3,

--- a/src/partials/header.hbs
+++ b/src/partials/header.hbs
@@ -36,8 +36,10 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1.0.0-rc.1/leaflet.css" />
   <script src="https://cdn.jsdelivr.net/leaflet/1.0.0-rc.1/leaflet-src.js"></script>
 
-  <!-- Load Esri Leaflet from CDN -->
+  <!-- Load Esri Leaflet -->
+  <!--script src="/js/linked/dist/esri-leaflet-debug.js"></script-->
   <script src="https://cdn.jsdelivr.net/leaflet.esri/{{package.version}}/esri-leaflet.js"></script>
+
   <script src="https://cdn.jsdelivr.net/jsdelivr-rum/latest/jsdelivr-rum.min.js"></script>
 
   {{#if siteData.isDev}}


### PR DESCRIPTION
resolves #30 (among other things)

* bumped version here to `2.0.0` (so that we pull from the right CDN once its there)
* fixed an oldIE bug in the secure arcgis server sample (because it doesn't know about `window.location.origin`)
* started rounding the magnitudes of earthquakes in the dynamic identify sample