### PR TITLE
Correct invalid closing </option> tags

### DIFF
--- a/src/pages/examples/switching-basemaps.hbs
+++ b/src/pages/examples/switching-basemaps.hbs
@@ -22,14 +22,14 @@ layout: example.hbs
 
 <div id="basemaps-wrapper" class="leaflet-bar">
   <select name="basemaps" id="basemaps" onChange="changeBasemap(basemaps)">
-    <option value="Topographic">Topographic<options>
+    <option value="Topographic">Topographic</option>
     <option value="Streets">Streets</option>
-    <option value="NationalGeographic">National Geographic<options>
-    <option value="Oceans">Oceans<options>
-    <option value="Gray">Gray<options>
-    <option value="DarkGray">Dark Gray<options>
-    <option value="Imagery">Imagery<options>
-    <option value="ShadedRelief">Shaded Relief<options>
+    <option value="NationalGeographic">National Geographic</option>
+    <option value="Oceans">Oceans</option>
+    <option value="Gray">Gray</option>
+    <option value="DarkGray">Dark Gray</option>
+    <option value="Imagery">Imagery</option>
+    <option value="ShadedRelief">Shaded Relief</option>
   </select>
 </div>
 


### PR DESCRIPTION
This HTML example appears to contain invalid HTML for the closing option tag.