### PR TITLE
bump geocoder and add more doc

### DIFF
--- a/src/pages/api-reference/controls/geosearch.md
+++ b/src/pages/api-reference/controls/geosearch.md
@@ -143,11 +143,12 @@ All providers share the following options:
 
 Option | Type | Default | Description
 --- | --- | --- | ---
-`countries` | `String` `[Strings]` | null | Limit results to one or more countries. Any ISO 3166 2 or 3 digit [country code supported by the ArcGIS World Geocode service](https://developers.arcgis.com/rest/geocode/api-reference/geocode-coverage.htm) is allowed. *Note* using an array of country codes may result in inaccurate results even when a specific suggestion is supplied.
+`countries` | `String` `[Strings]` | null | Limit results to one or more countries. Any ISO 3166 2 or 3 digit [country code](https://developers.arcgis.com/rest/geocode/api-reference/geocode-coverage.htm)  supported by the ArcGIS World Geocode service is allowed. *Note*: using an array of country codes may result in inaccurate results even when a specific suggestion is supplied.
 `categories` | `String` `[Strings]` | null | Limit results to one or more categories. See the [list of valid categories](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-category-filtering.htm#ESRI_SECTION1_502B3FE2028145D7B189C25B1A00E17B) for possible values.
 `forStorage` | `Boolean` | false | Indicates whether results will be stored permanently.  More information can be found [here](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-free-vs-paid.htm).
+`token` | `String` | `null` | Will use this token to authenticate all calls to the service.
 
-Results from the `arcgisOnlineProvider` will have an additional `properties` key which will correspond with [all available fields on the ArcGIS Online World Geocode service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-service-output.htm#ESRI_SECTION1_42D7D3D0231241E9B656C01438209440)
+Results from the `arcgisOnlineProvider` will have an additional `properties` key which will correspond with [all available fields](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-service-output.htm#ESRI_SECTION1_42D7D3D0231241E9B656C01438209440) in the World Geocode service
 
 ##### geocodeServiceProvider
 

--- a/src/pages/api-reference/layers/basemap-layer.md
+++ b/src/pages/api-reference/layers/basemap-layer.md
@@ -26,6 +26,7 @@ Inherits from [`L.TileLayer`](http://leafletjs.com/reference.html#tilelayer)
     </tbody>
 </table>
 
+
 ##### Basemaps
 
 These maps have worldwide coverage at a variety of zoom levels.
@@ -55,7 +56,11 @@ These are optional layers that add extra text labels to the basemaps.
 
 ### Options
 
-`L.esri.TiledMapLayer` accepts all [`L.TileLayer`](http://leafletjs.com/reference.html#tilelayer-options) options.
+`L.esri.basemapLayer` also accepts all [`L.TileLayer`](http://leafletjs.com/reference.html#tilelayer-options) options.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `token` | `String` | `null` | Will use this token to authenticate all calls to the service. |
 
 ### Methods
 

--- a/src/pages/download/index.md
+++ b/src/pages/download/index.md
@@ -26,8 +26,8 @@ All builds of Esri Leaflet are available for download on [GitHub](https://github
 <script src="https://cdn.jsdelivr.net/leaflet.esri.clustered-feature-layer/2.0.0-beta.1/esri-leaflet-clustered-feature-layer.js"></script>
 
 <!-- Geocoding Control -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.0/esri-leaflet-geocoder.css">
-<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.0/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.css">
+<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.js"></script>
 
 <!-- Renderers Plugin -->
 <script src="https://cdn.jsdelivr.net/leaflet.esri.renderers/2.0.2/esri-leaflet-renderers.js"></script>

--- a/src/pages/examples/geocoding-control.hbs
+++ b/src/pages/examples/geocoding-control.hbs
@@ -4,8 +4,8 @@ description: Using the geocoding control to search for addresses and center the 
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.0/esri-leaflet-geocoder.css">
-<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.0/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.css">
+<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.js"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/reverse-geocoding.hbs
+++ b/src/pages/examples/reverse-geocoding.hbs
@@ -4,8 +4,8 @@ description: Query the closest address to a given point with the Esri Leaflet Ge
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.0/esri-leaflet-geocoder.css">
-<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.0/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.css">
+<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.js"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/search-feature-layer.hbs
+++ b/src/pages/examples/search-feature-layer.hbs
@@ -4,8 +4,8 @@ description: Searches features layers for matching text in addition to geocoding
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.0/esri-leaflet-geocoder.css">
-<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.0/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.css">
+<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.js"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/search-map-service.hbs
+++ b/src/pages/examples/search-map-service.hbs
@@ -4,8 +4,8 @@ description: In addition to geocoding addresses and points of interest, you can 
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.0/esri-leaflet-geocoder.css">
-<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.0/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.css">
+<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.js"></script>
 
 <div id="map"></div>
 


### PR DESCRIPTION
clarify that a token can be passed to `L.esri.basemapLayer` and the `arcgisOnlineProvider` geosearch provider.