### PR TITLE
Rename socketFeatureLayer plugin

### DIFF
--- a/src/pages/plugins/index.hbs
+++ b/src/pages/plugins/index.hbs
@@ -116,13 +116,13 @@ class: plugins
 
       <div class="panel">
         <div class="card">
-          <h3><a href="https://github.com/rowanwins/esri-leaflet-socket">SocketFeatureLayer</a></h3>
+          <h3><a href="https://github.com/rowanwins/esri-leaflet-stream">StreamFeatureLayer</a></h3>
           <p>
             A plugin for displaying Stream layers published to ArcGIS Server using <a href="http://www.esri.com/software/arcgis/arcgisserver/extensions/geoevent-extension">GeoEvent</a>.
           </p>
-          <iframe src="https://ghbtns.com/github-btn.html?user=rowanwins&repo=esri-leaflet-socket&type=fork&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+          <iframe src="https://ghbtns.com/github-btn.html?user=rowanwins&repo=esri-leaflet-stream&type=fork&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
           <br>
-          <iframe src="https://ghbtns.com/github-btn.html?user=rowanwins&repo=esri-leaflet-socket&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+          <iframe src="https://ghbtns.com/github-btn.html?user=rowanwins&repo=esri-leaflet-stream&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
         </div>
       </div>
 


### PR DESCRIPTION
I've renamed the socketFeatureLayer to StreamFeatureLayer for consistency everywhere.