### PR TITLE
L.esri.FeatureLayer Gridded Queries/ bindPopup correction

### DIFF
--- a/src/pages/api-reference/layers/clustered-feature-layer.md
+++ b/src/pages/api-reference/layers/clustered-feature-layer.md
@@ -170,7 +170,7 @@ In additon to these events `L.esri.FeatureLayer` also fires the following [Mouse
             <td>
               Defines a function that will return HTML to be bound to a popup on each feature.
 <pre class="js"><code>featureLayer.bindPopup(function(features){
-  return "Name: " + features.properties.NAME;
+  return "Name: " + features.feature.properties.NAME;
 });</code></pre>
             </td>
         </tr>

--- a/src/pages/api-reference/layers/feature-layer.md
+++ b/src/pages/api-reference/layers/feature-layer.md
@@ -218,7 +218,7 @@ In addition to the events above, `L.esri.FeatureLayer` also fires the following 
             <td>
               Defines a function that will return HTML to be bound to a popup on each feature.
 <pre class="js"><code>featureLayer.bindPopup(function(features){
-  return "Name: " + features.properties.NAME;
+  return "Name: " + features.feature.properties.NAME;
 });</code></pre>
             </td>
         </tr>

--- a/src/pages/api-reference/layers/feature-layer.md
+++ b/src/pages/api-reference/layers/feature-layer.md
@@ -25,6 +25,8 @@ Note that the Feature Layer URL ends in `/FeatureServer/{LAYER_ID}`.
 
 You can create a new empty feature service with a single layer on the [ArcGIS for Developers website](https://developers.arcgis.com/en/hosted-data/#/new) or you can use ArcGIS Online to [create a Feature Service from a CSV or Shapefile](https://doc.arcgis.com/en/arcgis-online/share-maps/publish-features.htm).
 
+Note: `L.esri.FeatureLayer` uses gridded queries to retrieve and cache tiles (of features) that intersect the map extent, similar to ArcGIS JS API's MODE_ONDEMAND. For more information see: https://developers.arcgis.com/javascript/3/jshelp/best_practices_feature_layers.html
+
 ### Constructor
 
 <table>


### PR DESCRIPTION
Specifies that gridded queries (MODE_ONDEMAND) are enabled by default when using L.esri.FeatureLayer.

Described in this issue: https://github.com/Esri/esri-leaflet/issues/12
And implemented in this PR: https://github.com/Esri/esri-leaflet/pull/112

I was specifically searching for a tool to allow me to use MODE_ONDEMAND within Leaflet and it took quite a bit of research to find that esri-leaflet does this by default.

Welcome comments regarding necessity or description of feature. Cheers!

PS: Sorry for the stale already-merged commits, cant figure out why they are showing in this pull request.