### PR TITLE
Fixed example code for featureLayer.bindPopup in feature-layer.md

### DIFF
--- a/src/pages/api-reference/layers/clustered-feature-layer.md
+++ b/src/pages/api-reference/layers/clustered-feature-layer.md
@@ -165,21 +165,6 @@ In additon to these events `L.esri.FeatureLayer` also fires the following [Mouse
   };
 })</code></pre>
         <tr>
-            <td><code>bindPopup({{{param 'Function' 'fn'}}}, {{{param 'PopupOptions' 'popupOptions' 'http://leafletjs.com/reference.html#popup-options'}}})</code></td>
-            <td><code>this</code></td>
-            <td>
-              Defines a function that will return HTML to be bound to a popup on each feature.
-<pre class="js"><code>featureLayer.bindPopup(function(features){
-  return "Name: " + features.properties.NAME;
-});</code></pre>
-            </td>
-        </tr>
-        <tr>
-            <td><code>unbindPopup()</code></td>
-            <td><code>this</code></td>
-            <td>Removed a popup previously bound with `bindPopup`.</td>
-        </tr>
-        <tr>
             <td><code>eachFeature({{{param 'Function' 'fn'}}}, {{{param 'Object' 'context'}}})</code></td>
             <td><code>this</code></td>
             <td>

--- a/src/pages/api-reference/layers/feature-layer.md
+++ b/src/pages/api-reference/layers/feature-layer.md
@@ -213,21 +213,6 @@ In addition to the events above, `L.esri.FeatureLayer` also fires the following 
             <td>Given the ID of a feature, reset that feature to the original style.</td>
         </tr>
         <tr>
-            <td><code>bindPopup({{{param 'Function' 'fn'}}}, {{{param 'PopupOptions' 'popupOptions' 'http://leafletjs.com/reference.html#popup-options'}}})</code></td>
-            <td><code>this</code></td>
-            <td>
-              Defines a function that will return HTML to be bound to a popup on each feature.
-<pre class="js"><code>featureLayer.bindPopup(function(features){
-  return "Name: " + features.properties.NAME;
-});</code></pre>
-            </td>
-        </tr>
-        <tr>
-            <td><code>unbindPopup()</code></td>
-            <td><code>this</code></td>
-            <td>Removed a popup previously bound with `bindPopup`.</td>
-        </tr>
-        <tr>
             <td><code>eachFeature({{{param 'Function' 'fn'}}}, {{{param 'Object' 'context'}}})</code></td>
             <td><code>this</code></td>
             <td>


### PR DESCRIPTION
The existing example worked for older versions of esri leaflet but is updated to the proper form for the current version. 

I didn't update featureClusteredLayer.bindPopup because I haven't looked into getting Leaflet/Leaflet.markercluster to work with esri/esri-leaflet, and esri/esri-leaflet-clustered-layer plugin only works with the older version of esri-leaflet that uses the outdated syntax.

Let me know if you need more detail.