### PR TITLE
Added note about default use of gridded queries (MODE_ONDEMAND) when …

### DIFF
--- a/src/pages/api-reference/layers/feature-layer.md
+++ b/src/pages/api-reference/layers/feature-layer.md
@@ -25,7 +25,7 @@ Note that the Feature Layer URL ends in `/FeatureServer/{LAYER_ID}`.
 
 You can create a new empty feature service with a single layer on the [ArcGIS for Developers website](https://developers.arcgis.com/en/hosted-data/#/new) or you can use ArcGIS Online to [create a Feature Service from a CSV or Shapefile](https://doc.arcgis.com/en/arcgis-online/share-maps/publish-features.htm).
 
-Note: `L.esri.FeatureLayer` uses gridded queries to retrieve and cache tiles (of features) that intersect the map extent, similar to ArcGIS JS API's MODE_ONDEMAND. For more information see: https://developers.arcgis.com/javascript/3/jshelp/best_practices_feature_layers.html
+`L.esri.FeatureLayer` divides the current map extent into a grid of individual cells and uses them to fire queries to fetch nearby features. This technique is comparable to [MODE_ONDEMAND](https://developers.arcgis.com/javascript/3/jshelp/best_practices_feature_layers.html) in the ArcGIS API for JavaScript.
 
 ### Constructor
 

--- a/src/pages/api-reference/layers/feature-layer.md
+++ b/src/pages/api-reference/layers/feature-layer.md
@@ -25,6 +25,8 @@ Note that the Feature Layer URL ends in `/FeatureServer/{LAYER_ID}`.
 
 You can create a new empty feature service with a single layer on the [ArcGIS for Developers website](https://developers.arcgis.com/en/hosted-data/#/new) or you can use ArcGIS Online to [create a Feature Service from a CSV or Shapefile](https://doc.arcgis.com/en/arcgis-online/share-maps/publish-features.htm).
 
+Note: `L.esri.FeatureLayer` uses gridded queries to retrieve and cache tiles (of features) that intersect the map extent, similar to ArcGIS JS API's MODE_ONDEMAND. For more information see: https://developers.arcgis.com/javascript/3/jshelp/best_practices_feature_layers.html
+
 ### Constructor
 
 <table>


### PR DESCRIPTION
…adding a featureLayer

I really love that esri-leaflet uses gridded queries by default, but it took me awhile to find out that it did prior to using it even though I was specifically searching for that capability.

Let me know what you think.