### PR TITLE
closes #71, #57

### DIFF
--- a/data/siteData.json
+++ b/data/siteData.json
@@ -1,3 +1,4 @@
 {
-  "isDev": true
+  "isDev": true,
+  "localSource": false
 }

--- a/src/pages/api-reference/tasks/query.md
+++ b/src/pages/api-reference/tasks/query.md
@@ -73,7 +73,7 @@ layout: documentation.hbs
         <tr>
             <td><code>nearby({{{param 'LatLng' 'latlng' 'http://leafletjs.com/reference.html#latlng'}}}, {{{param 'Integer' 'distance'}}})</code></td>
             <td><code>this</code></td>
-            <td>Queries features a given distance in meters around a <a href="http://leafletjs.com/reference.html#latlng">LatLng</a>. <small>Only available for Feature Layers hosted on ArcGIS Online or ArcGIS Server 10.3.</small></td>
+            <td>Queries features a given distance in meters around a <a href="http://leafletjs.com/reference.html#latlng">LatLng</a>. <small>Only available for Feature Layers hosted on ArcGIS Online or ArcGIS Server 10.3 that include the capability <code>supportQueryWithDistance</code>.</small></td>
         </tr>
         <tr>
             <td><code>where({{{param 'String' 'where'}}})</code></td>

--- a/src/partials/header.hbs
+++ b/src/partials/header.hbs
@@ -35,16 +35,17 @@
   {{#if siteData.isDev}}
     <!-- 'livereload' for development -->
     <script src="//localhost:35729/livereload.js"></script>
+  {{else}}
+    <!-- use CDN -->
+    <script src="https://cdn.jsdelivr.net/jsdelivr-rum/latest/jsdelivr-rum.min.js"></script>
+  {{/if}}
 
+  {{#if siteData.localSource}}
     <!-- Load local linked resources -->
     <link rel="stylesheet" href="/js/linked/leaflet-dist/leaflet.css" />
     <script src="/js/linked/leaflet-dist/leaflet-src.js"></script>
     <script src="/js/linked/esri-leaflet-dist/esri-leaflet-debug.js"></script>
   {{else}}
-
-    <!-- use CDN -->
-    <script src="https://cdn.jsdelivr.net/jsdelivr-rum/latest/jsdelivr-rum.min.js"></script>
-
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1.0.0-rc.3/leaflet.css" />
     <script src="https://cdn.jsdelivr.net/leaflet/1.0.0-rc.3/leaflet-src.js"></script>
     <script src="https://cdn.jsdelivr.net/leaflet.esri/{{package.version}}/esri-leaflet-debug.js"></script>


### PR DESCRIPTION
this change ensures that the local dev environment doesn't automatically start looking for locally linked raw source for Leaflet and Esri Leaflet to display samples.

also added a bit more clarification to `query.nearby()`