### PR TITLE
2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esri-leaflet-doc",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": true,
   "author": "Patrick Arlt <parlt@esri.com> (http://patrickarlt.com)",
   "contributors": [
@@ -14,7 +14,7 @@
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-connect": "^0.11.2",
     "grunt-contrib-copy": "^0.8.2",
-    "grunt-contrib-imagemin": "^1.0.0",
+    "grunt-contrib-imagemin": "^1.0.1",
     "grunt-contrib-jshint": "^0.11.3",
     "grunt-contrib-sass": "^0.9.2",
     "grunt-contrib-uglify": "^0.11.0",

--- a/src/layouts/example.hbs
+++ b/src/layouts/example.hbs
@@ -21,11 +21,11 @@ layout: page.hbs
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
 
   <!-- Load Leaflet from CDN-->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1.0.0-rc.3/leaflet.css" />
-  <script src="https://cdn.jsdelivr.net/leaflet/1.0.0-rc.3/leaflet-src.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@1.0.0-rc.3"></script>
 
   <!-- Load Esri Leaflet from CDN -->
-  <script src="https://cdn.jsdelivr.net/leaflet.esri/{{package.version}}/esri-leaflet.js"></script>
+  <script src="https://unpkg.com/esri-leaflet@{{package.version}}"></script>
 
   <style>
     body { margin:0; padding:0; }

--- a/src/layouts/example.hbs
+++ b/src/layouts/example.hbs
@@ -22,7 +22,7 @@ layout: page.hbs
 
   <!-- Load Leaflet from CDN-->
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.css" />
-  <script src="https://unpkg.com/leaflet@1.0.0-rc.3"></script>
+  <script src="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet-src.js"></script>
 
   <!-- Load Esri Leaflet from CDN -->
   <script src="https://unpkg.com/esri-leaflet@{{package.version}}"></script>

--- a/src/pages/download/index.md
+++ b/src/pages/download/index.md
@@ -22,6 +22,9 @@ All builds of Esri Leaflet are available for download on [GitHub](https://github
 #### Other Plugins
 
 ```xml
+<!-- ArcGIS Online Vector Basemaps -->
+<script src="https://unpkg.com/esri-leaflet-vector@1.0.0"></script>
+
 <!-- Clustered Feature Layer -->
 <script src="https://unpkg.com/esri-leaflet-cluster@2.0.0"></script>
 
@@ -29,8 +32,8 @@ All builds of Esri Leaflet are available for download on [GitHub](https://github
 <script src="https://unpkg.com/esri-leaflet-heatmap@2.0.0"></script>
 
 <!-- Geocoding Control -->
-<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.1/dist/esri-leaflet-geocoder.css">
-<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.1"></script>
+<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.3/dist/esri-leaflet-geocoder.css">
+<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.3"></script>
 
 <!-- Renderers Plugin -->
 <script src="https://unpkg.com/esri-leaflet-renderers@2.0.2"></script>

--- a/src/pages/download/index.md
+++ b/src/pages/download/index.md
@@ -16,24 +16,27 @@ All builds of Esri Leaflet are available for download on [GitHub](https://github
 #### Esri Leaflet
 
 ```xml
-<script src="https://cdn.jsdelivr.net/leaflet.esri/{{package.version}}/esri-leaflet.js"></script>
+<script src="https://unpkg.com/esri-leaflet@{{package.version}}"></script>
 ```
 
 #### Other Plugins
 
 ```xml
 <!-- Clustered Feature Layer -->
-<script src="https://cdn.jsdelivr.net/leaflet.esri.clustered-feature-layer/2.0.0-beta.1/esri-leaflet-clustered-feature-layer.js"></script>
+<script src="https://unpkg.com/esri-leaflet-cluster@2.0.0"></script>
+
+<!-- Heatmap Feature Layer -->
+<script src="https://unpkg.com/esri-leaflet-heatmap@2.0.0"></script>
 
 <!-- Geocoding Control -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.css">
-<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.1/dist/esri-leaflet-geocoder.css">
+<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.1"></script>
 
 <!-- Renderers Plugin -->
-<script src="https://cdn.jsdelivr.net/leaflet.esri.renderers/2.0.2/esri-leaflet-renderers.js"></script>
+<script src="https://unpkg.com/esri-leaflet-renderers@2.0.2"></script>
 
 <!-- Geoprocessing Plugin -->
-<script src="https://cdn.jsdelivr.net/leaflet.esri.gp/2.0.2/esri-leaflet-gp.js"></script>
+<script src="https://unpkg.com/esri-leaflet-gp@2.0.1"></script>
 ```
 # npm
 

--- a/src/pages/examples/geocoding-control.hbs
+++ b/src/pages/examples/geocoding-control.hbs
@@ -4,8 +4,8 @@ description: Using the geocoding control to search for addresses and center the 
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.1/dist/esri-leaflet-geocoder.css">
-<script src="<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.1"></script>"></script>
+<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.2/dist/esri-leaflet-geocoder.css">
+<script src="<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.2"></script>"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/geocoding-control.hbs
+++ b/src/pages/examples/geocoding-control.hbs
@@ -4,8 +4,8 @@ description: Using the geocoding control to search for addresses and center the 
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.css">
-<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.1/dist/esri-leaflet-geocoder.css">
+<script src="<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.1"></script>"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/geocoding-control.hbs
+++ b/src/pages/examples/geocoding-control.hbs
@@ -4,8 +4,8 @@ description: Using the geocoding control to search for addresses and center the 
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.2/dist/esri-leaflet-geocoder.css">
-<script src="<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.2"></script>"></script>
+<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.3/dist/esri-leaflet-geocoder.css">
+<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.3"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/gp-plugin.hbs
+++ b/src/pages/examples/gp-plugin.hbs
@@ -4,7 +4,7 @@ description: This demo relies on the <a href="https://github.com/jgravois/esri-l
 layout: example.hbs
 ---
 
-<script src="https://cdn.jsdelivr.net/leaflet.esri.gp/2.0.0/esri-leaflet-gp.js"></script>
+<script src="https://unpkg.com/esri-leaflet-gp@2.0.1"></script>
 
 <style>
   #info-pane {

--- a/src/pages/examples/non-mercator-projection-2.hbs
+++ b/src/pages/examples/non-mercator-projection-2.hbs
@@ -37,9 +37,7 @@ in production you'd be better off hosting these libraries yourself -->
     // to do: overlay is misaligned at world scale, needs to figure out why.
     maxZoom: 3,
     minZoom: 3,
-    continuousWorld: true,
-    attribution: 'maverick',
-    errorTileUrl: 'https://downloads2.esri.com/support/TechArticles/blank256.png'
+    continuousWorld: true
   }).addTo(map);
 
   // Dynamic map layers are projected by ArcGIS Server itself before the image is retrieved

--- a/src/pages/examples/non-mercator-projection.hbs
+++ b/src/pages/examples/non-mercator-projection.hbs
@@ -39,9 +39,7 @@ in production you'd be better off hosting these libraries yourself -->
     url: 'http://maverick.arcgis.com/ArcGIS/rest/services/World_Mollweide/MapServer',
     maxZoom: 3,
     minZoom: 1,
-    continuousWorld: true,
-    attribution: 'maverick',
-    errorTileUrl: 'http://downloads2.esri.com/support/TechArticles/blank256.png'
+    continuousWorld: true
   }).addTo(map);
 
   // feature layers will be requested in WGS84 (4326) and reprojected on the client

--- a/src/pages/examples/renderers-plugin.hbs
+++ b/src/pages/examples/renderers-plugin.hbs
@@ -5,7 +5,7 @@ layout: example.hbs
 ---
 
 <!-- Load Esri Leaflet Renderers -->
-<script src="https://cdn.jsdelivr.net/leaflet.esri.renderers/2.0.2/esri-leaflet-renderers.js"></script>
+<script src="https://unpkg.com/esri-leaflet-renderers@2.0.2"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/reverse-geocoding.hbs
+++ b/src/pages/examples/reverse-geocoding.hbs
@@ -4,8 +4,8 @@ description: Query the closest address to a given point with the Esri Leaflet Ge
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.css">
-<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.1/dist/esri-leaflet-geocoder.css">
+<script src="<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.1"></script>"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/reverse-geocoding.hbs
+++ b/src/pages/examples/reverse-geocoding.hbs
@@ -4,8 +4,8 @@ description: Query the closest address to a given point with the Esri Leaflet Ge
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.2/dist/esri-leaflet-geocoder.css">
-<script src="<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.2"></script>"></script>
+<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.3/dist/esri-leaflet-geocoder.css">
+<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.3"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/reverse-geocoding.hbs
+++ b/src/pages/examples/reverse-geocoding.hbs
@@ -4,8 +4,8 @@ description: Query the closest address to a given point with the Esri Leaflet Ge
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.1/dist/esri-leaflet-geocoder.css">
-<script src="<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.1"></script>"></script>
+<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.2/dist/esri-leaflet-geocoder.css">
+<script src="<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.2"></script>"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/search-feature-layer.hbs
+++ b/src/pages/examples/search-feature-layer.hbs
@@ -4,8 +4,8 @@ description: Searches features layers for matching text in addition to geocoding
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.2/dist/esri-leaflet-geocoder.css">
-<script src="<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.2"></script>"></script>
+<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.3/dist/esri-leaflet-geocoder.css">
+<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.3"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/search-feature-layer.hbs
+++ b/src/pages/examples/search-feature-layer.hbs
@@ -4,8 +4,8 @@ description: Searches features layers for matching text in addition to geocoding
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.1/dist/esri-leaflet-geocoder.css">
-<script src="<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.1"></script>"></script>
+<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.2/dist/esri-leaflet-geocoder.css">
+<script src="<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.2"></script>"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/search-feature-layer.hbs
+++ b/src/pages/examples/search-feature-layer.hbs
@@ -4,8 +4,8 @@ description: Searches features layers for matching text in addition to geocoding
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.css">
-<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.1/dist/esri-leaflet-geocoder.css">
+<script src="<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.1"></script>"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/search-map-service.hbs
+++ b/src/pages/examples/search-map-service.hbs
@@ -4,8 +4,8 @@ description: In addition to geocoding addresses and points of interest, you can 
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.2/dist/esri-leaflet-geocoder.css">
-<script src="<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.2"></script>"></script>
+<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.3/dist/esri-leaflet-geocoder.css">
+<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.3"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/search-map-service.hbs
+++ b/src/pages/examples/search-map-service.hbs
@@ -4,8 +4,8 @@ description: In addition to geocoding addresses and points of interest, you can 
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.1/dist/esri-leaflet-geocoder.css">
-<script src="<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.1"></script>"></script>
+<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.2/dist/esri-leaflet-geocoder.css">
+<script src="<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.2"></script>"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/search-map-service.hbs
+++ b/src/pages/examples/search-map-service.hbs
@@ -4,8 +4,8 @@ description: In addition to geocoding addresses and points of interest, you can 
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.css">
-<script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.1/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.1.1/dist/esri-leaflet-geocoder.css">
+<script src="<script src="https://unpkg.com/esri-leaflet-geocoder@2.1.1"></script>"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/stream-plugin.hbs
+++ b/src/pages/examples/stream-plugin.hbs
@@ -4,8 +4,7 @@ description: This demo displays a real-time data feed from a service published u
 layout: example.hbs
 ---
 
-<script src="https://cdn.rawgit.com/rowanwins/esri-leaflet-stream/gh-pages/dist/esri-leaflet-stream.min.js"></script>
-
+<script src="https://unpkg.com/esri-leaflet-stream@1.0.0/dist/esri-leaflet-stream.min.js"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/vector-basemap.hbs
+++ b/src/pages/examples/vector-basemap.hbs
@@ -1,0 +1,54 @@
+---
+title: Vector Basemaps
+description: Display ArcGIS Online vector basemaps. Notice that the map attribution updates automatically as users pan and zoom in accordance with Esri's <a href='https://github.com/esri/esri-leaflet#terms'>Terms of Use</a>.
+layout: example.hbs
+---
+
+<script src="https://unpkg.com/esri-leaflet-vector@1.0.1"></script>
+
+<style>
+  #basemaps-wrapper {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 400;
+    background: white;
+    padding: 10px;
+  }
+  #basemaps {
+    margin-bottom: 5px;
+  }
+</style>
+
+<div id="map"></div>
+
+<div id="basemaps-wrapper" class="leaflet-bar">
+  <select name="basemaps" id="basemaps" onChange="changeBasemap(basemaps)">
+    <option value="Topographic">Topographic</option>
+    <option value="Gray">Gray</option>
+    <option value="DarkGray">Dark Gray</option>
+    <option value="Navigation">Navigation</option>
+    <option value="Streets">Streets</option>
+    <option value="StreetsNight">Streets Night</option>
+    <option value="StreetsRelief">Streets Relief</option>
+  </select>
+</div>
+
+<script>
+  var map = L.map('map').setView([-33.87, 150.77], 10);
+  var layer = L.esri.Vector.basemap('Topographic').addTo(map);
+
+  function setBasemap(basemap) {
+    if (layer) {
+      map.removeLayer(layer);
+    }
+
+    layer = L.esri.Vector.basemap(basemap);
+    map.addLayer(layer);
+  }
+
+  function changeBasemap(basemaps){
+    var basemap = basemaps.value;
+    setBasemap(basemap);
+  }
+</script>

--- a/src/pages/plugins/index.hbs
+++ b/src/pages/plugins/index.hbs
@@ -20,7 +20,7 @@ class: plugins
       <div class="card">
         <h3><a href="https://github.com/Esri/esri-leaflet-renderers">Renderers</a></h3>
         <p>
-          Ensure that symbology defined by ArcGIS Server and ArcGIS Online for  feature layers is inherited in Leaflet.
+          Ensure that symbology defined by ArcGIS Server and ArcGIS Online for feature layers is inherited in Leaflet.
         </p>
         <iframe src="https://ghbtns.com/github-btn.html?user=esri&repo=esri-leaflet-renderers&type=fork&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
         <br>
@@ -30,18 +30,42 @@ class: plugins
 
     <div class="panel">
       <div class="card">
-        <h3><a href="https://github.com/Esri/esri-leaflet-heatmap-feature-layer">Heatmap Feature Layer</a></h3>
+        <h3><a href="https://github.com/Esri/esri-leaflet-vector/">Vector Tiles</a></h3>
         <p>
-          Visualize feature layers with heatmaps via <a href="https://github.com/Leaflet/Leaflet.heat">Leaflet.heat</a>.
+          A plugin for Esri Leaflet to visualize Vector tiles from ArcGIS Online.
         </p>
-        <iframe src="https://ghbtns.com/github-btn.html?user=esri&repo=esri-leaflet-heatmap&type=fork&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+        <iframe src="https://ghbtns.com/github-btn.html?user=esri&repo=esri-leaflet-vector&type=fork&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
         <br>
-        <iframe src="https://ghbtns.com/github-btn.html?user=esri&repo=esri-leaflet-heatmap&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+        <iframe src="https://ghbtns.com/github-btn.html?user=esri&repo=esri-leaflet-vector&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
       </div>
     </div>
   </div>
 
   <div class="row clearfix">
+    <div class="panel">
+      <div class="card">
+        <h3><a href="https://github.com/ynunokawa/L.esri.WebMap">WebMap</a></h3>
+        <p>
+          A plugin for loading Web maps created in <a href='https://www.arcgis.com'>ArcGIS</a> using their id!
+        </p>
+        <iframe src="https://ghbtns.com/github-btn.html?user=ynunokawa&repo=L.esri.WebMap&type=fork&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+        <br>
+        <iframe src="https://ghbtns.com/github-btn.html?user=ynunokawa&repo=L.esri.WebMap&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="card">
+          <h3><a href="https://github.com/rowanwins/esri-leaflet-stream">Stream Feature Layer</a></h3>
+          <p>
+            A plugin for displaying Stream layers published to ArcGIS Server using <a href="http://www.esri.com/software/arcgis/arcgisserver/extensions/geoevent-extension">GeoEvent</a>.
+          </p>
+          <iframe src="https://ghbtns.com/github-btn.html?user=rowanwins&repo=esri-leaflet-stream&type=fork&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+          <br>
+          <iframe src="https://ghbtns.com/github-btn.html?user=rowanwins&repo=esri-leaflet-stream&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+      </div>
+    </div>
+
     <div class="panel">
       <div class="card">
         <h3><a href="https://github.com/Esri/esri-leaflet-clustered-feature-layer">Clustered Feature Layer</a></h3>
@@ -53,7 +77,47 @@ class: plugins
         <iframe src="https://ghbtns.com/github-btn.html?user=esri&repo=esri-leaflet-cluster&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
       </div>
     </div>
+  </div>
 
+  <div class="row clearfix">
+    <div class="panel">
+      <div class="card">
+        <h3><a href="https://github.com/Esri/esri-leaflet-heatmap-feature-layer">Heatmap Feature Layer</a></h3>
+        <p>
+          Visualize feature layers with heatmaps via <a href="https://github.com/Leaflet/Leaflet.heat">Leaflet.heat</a>.
+        </p>
+        <iframe src="https://ghbtns.com/github-btn.html?user=esri&repo=esri-leaflet-heatmap&type=fork&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+        <br>
+        <iframe src="https://ghbtns.com/github-btn.html?user=esri&repo=esri-leaflet-heatmap&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="card">
+        <h3><a href="https://github.com/SVoyt/esri-leaflet-dynamic-advanced">Dynamic Map Layer</a></h3>
+        <p>
+          A more advanced DynamicMapLayer implementation that includes support for continuous panning across the dateline.
+        </p>
+        <iframe src="https://ghbtns.com/github-btn.html?user=svoyt&repo=esri-leaflet-dynamic-advanced&type=fork&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+        <br>
+        <iframe src="https://ghbtns.com/github-btn.html?user=svoyt&repo=esri-leaflet-dynamic-advanced&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="card">
+        <h3><a href="https://github.com/Esri/Leaflet.shapeMarkers">shapeMarkers</a></h3>
+        <p>
+          Generic, fixed size, shape marker symbols for points in Leaflet.
+        </p>
+        <iframe src="https://ghbtns.com/github-btn.html?user=Esri&repo=Leaflet.shapeMarkers&type=fork&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+        <br>
+        <iframe src="https://ghbtns.com/github-btn.html?user=Esri&repo=Leaflet.shapeMarkers&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+      </div>
+    </div>
+  </div>
+
+  <div class="row clearfix">
     <div class="panel">
       <div class="card">
         <h3><a href="https://github.com/jgravois/esri-leaflet-gp">Geoprocessing</a></h3>
@@ -68,64 +132,15 @@ class: plugins
 
     <div class="panel">
       <div class="card">
-        <h3><a href="https://github.com/jgravois/esri-leaflet-related">Related Records</a></h3>
-        <p>
-          Plugin to assist in querying ArcGIS Services for related records.
-        </p>
-        <iframe src="https://ghbtns.com/github-btn.html?user=jgravois&repo=esri-leaflet-related&type=fork&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
-        <br>
-        <iframe src="https://ghbtns.com/github-btn.html?user=jgravois&repo=esri-leaflet-related&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
-        </div>
+      <h3><a href="https://github.com/jgravois/esri-leaflet-related">Related Records</a></h3>
+      <p>
+        Plugin to assist in querying ArcGIS Services for related records.
+      </p>
+      <iframe src="https://ghbtns.com/github-btn.html?user=jgravois&repo=esri-leaflet-related&type=fork&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+      <br>
+      <iframe src="https://ghbtns.com/github-btn.html?user=jgravois&repo=esri-leaflet-related&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
       </div>
-
-      <div class="panel">
-        <div class="card">
-          <h3><a href="https://github.com/Esri/Leaflet.shapeMarkers">shapeMarkers</a></h3>
-          <p>
-            Generic, fixed size, shape marker symbols for points in Leaflet.
-          </p>
-          <iframe src="https://ghbtns.com/github-btn.html?user=Esri&repo=Leaflet.shapeMarkers&type=fork&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
-          <br>
-          <iframe src="https://ghbtns.com/github-btn.html?user=Esri&repo=Leaflet.shapeMarkers&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
-        </div>
-      </div>
-
-      <div class="panel">
-        <div class="card">
-          <h3><a href="https://github.com/SVoyt/esri-leaflet-dynamic-advanced">DynamicMapLayer Advanced</a></h3>
-          <p>
-            As named, a more advanced Dynamic Map Layer implementation that includes support for continuous panning across the dateline.
-          </p>
-          <iframe src="https://ghbtns.com/github-btn.html?user=svoyt&repo=esri-leaflet-dynamic-advanced&type=fork&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
-          <br>
-          <iframe src="https://ghbtns.com/github-btn.html?user=svoyt&repo=esri-leaflet-dynamic-advanced&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
-        </div>
-      </div>
-
-      <div class="panel">
-        <div class="card">
-          <h3><a href="https://github.com/ynunokawa/L.esri.WebMap">WebMap</a></h3>
-          <p>
-            A plugin for loading Web maps created in <a href='https://www.arcgis.com'>ArcGIS</a> using their id!
-          </p>
-          <iframe src="https://ghbtns.com/github-btn.html?user=ynunokawa&repo=L.esri.WebMap&type=fork&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
-          <br>
-          <iframe src="https://ghbtns.com/github-btn.html?user=ynunokawa&repo=L.esri.WebMap&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
-        </div>
-      </div>
-
-      <div class="panel">
-        <div class="card">
-          <h3><a href="https://github.com/rowanwins/esri-leaflet-stream">StreamFeatureLayer</a></h3>
-          <p>
-            A plugin for displaying Stream layers published to ArcGIS Server using <a href="http://www.esri.com/software/arcgis/arcgisserver/extensions/geoevent-extension">GeoEvent</a>.
-          </p>
-          <iframe src="https://ghbtns.com/github-btn.html?user=rowanwins&repo=esri-leaflet-stream&type=fork&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
-          <br>
-          <iframe src="https://ghbtns.com/github-btn.html?user=rowanwins&repo=esri-leaflet-stream&type=star&count=true" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
-        </div>
-      </div>
-
     </div>
   </div>
 </div>
+

--- a/src/partials/header.hbs
+++ b/src/partials/header.hbs
@@ -45,7 +45,7 @@
     <script src="/js/linked/esri-leaflet-dist/esri-leaflet-debug.js"></script>
   {{else}}
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.0.0-rc.3"></script>
+    <script src="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet-src.js"></script>
     <script src="https://unpkg.com/esri-leaflet@{{package.version}}"></script>
   {{/if}}
 

--- a/src/partials/header.hbs
+++ b/src/partials/header.hbs
@@ -36,8 +36,6 @@
     <!-- 'livereload' for development -->
     <script src="//localhost:35729/livereload.js"></script>
   {{else}}
-    <!-- use CDN -->
-    <script src="https://cdn.jsdelivr.net/jsdelivr-rum/latest/jsdelivr-rum.min.js"></script>
   {{/if}}
 
   {{#if siteData.localSource}}
@@ -46,9 +44,9 @@
     <script src="/js/linked/leaflet-dist/leaflet-src.js"></script>
     <script src="/js/linked/esri-leaflet-dist/esri-leaflet-debug.js"></script>
   {{else}}
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1.0.0-rc.3/leaflet.css" />
-    <script src="https://cdn.jsdelivr.net/leaflet/1.0.0-rc.3/leaflet-src.js"></script>
-    <script src="https://cdn.jsdelivr.net/leaflet.esri/{{package.version}}/esri-leaflet-debug.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.0.0-rc.3"></script>
+    <script src="https://unpkg.com/esri-leaflet@{{package.version}}"></script>
   {{/if}}
 
   <!-- Google Analytics -->

--- a/src/partials/sidebar-examples.hbs
+++ b/src/partials/sidebar-examples.hbs
@@ -34,7 +34,6 @@
     <a href="{{assets}}examples/visualizing-time-with-feature-layer.html">Time Enabled Services</a>
     <a href="{{assets}}examples/clustering-feature-layers.html">Clustering Points</a>
     <a href="{{assets}}examples/styling-clusters.html">Styling Clusters</a>
-    <a href="{{assets}}examples/stream-plugin.html">Stream Layer</a>
   </nav>
 
   <h5>Tile Layers</h5>
@@ -91,9 +90,10 @@
 
   <h5>Other Plugins</h5>
   <nav>
-    <a href="{{assets}}examples/gp-plugin.html">Geoprocessing</a>
     <a href="{{assets}}examples/renderers-plugin.html">Server Side Rendering</a>
+    <a href="{{assets}}examples/stream-plugin.html">Stream Layer</a>
     <a href="{{assets}}examples/webmap.html?id=22c504d229f14c789c5b49ebff38b941">Loading Webmaps</a>
+    <a href="{{assets}}examples/gp-plugin.html">Geoprocessing</a>
   </nav>
 
   <h5>Misc.</h5>

--- a/src/partials/sidebar-examples.hbs
+++ b/src/partials/sidebar-examples.hbs
@@ -5,6 +5,7 @@
     <a href="{{assets}}examples/basemap-with-labels.html">Basemap with Labels</a>
     <a href="{{assets}}examples/switching-basemaps.html">Switching Basemaps</a>
     <a href="{{assets}}examples/retina-basemap.html">Retina Basemap</a>
+    <a href="{{assets}}examples/vector-basemap.html">Vector Basemaps</a>
   </nav>
 
   <h5>Feature Layers</h5>


### PR DESCRIPTION
* bump esri-leaflet to `2.0.3`
* bump esri-leaflet-geocoder to `2.1.3`
* new esri-leaflet-vector `1.0.1` sample
* move links to unpkg.com
* manually bump `grunt-contrib-imagemin` (resolved errors on my machine rolling up those little buses)

resolves #82, #93