### PR TITLE
bump samples to leaflet 1.0.0 final!

### DIFF
--- a/src/layouts/example.hbs
+++ b/src/layouts/example.hbs
@@ -21,8 +21,8 @@ layout: page.hbs
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
 
   <!-- Load Leaflet from CDN-->
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.css" />
-  <script src="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet-src.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@1.0.0/dist/leaflet-src.js"></script>
 
   <!-- Load Esri Leaflet from CDN -->
   <script src="https://unpkg.com/esri-leaflet@{{package.version}}"></script>

--- a/src/pages/api-reference/controls/geosearch.md
+++ b/src/pages/api-reference/controls/geosearch.md
@@ -129,8 +129,6 @@ L.esri.Geocoding.Controls.geosearch({
 
 * `L.esri.Geocoding.geocodeServiceProvider`<br>uses an ArcGIS Server Geocode Service (and supports suggestions from ArcGIS Server 10.3+ enabled endpoints).
 
-#### Providers
-
 All providers share the following options:
 
 | Option | Type | Default | Description

--- a/src/pages/api-reference/tasks/query-related.md
+++ b/src/pages/api-reference/tasks/query-related.md
@@ -95,7 +95,7 @@ Accepts all [`L.esri.Task`](task.html#options) options. When used, the `url` opt
 
 | Property | Type | Description |
 | --- | --- | --- |
-| `features` | `[<L.geoJson>]`| The result of a valid request will be composed of an array of [L.geoJson](http://leafletjs.com/reference.html#geojson) features. |
+| `features` | `[<L.geoJSON>]`| The result of a valid request will be composed of an array of [L.geoJSON](http://leafletjs.com/reference.html#geojson) features. |
 
 Example
 

--- a/src/pages/examples/feature-layer-snapshot.hbs
+++ b/src/pages/examples/feature-layer-snapshot.hbs
@@ -19,7 +19,7 @@ layout: example.hbs
     url: neighborhoodsUrl
   }).where("NAME='HOLLYWOOD'").run(function(error, neighborhoods){
     // draw neighborhood on the map
-    var hollywood = L.geoJson(neighborhoods).addTo(map);
+    var hollywood = L.geoJSON(neighborhoods).addTo(map);
 
     // fit map to boundry
     map.fitBounds(hollywood.getBounds().pad(0.5));
@@ -28,7 +28,7 @@ layout: example.hbs
     L.esri.query({
       url: bikeParkingUrl
     }).where("BPSTYLE='STAPLE'").within(hollywood).run(function(error, bikeParking){
-      L.geoJson(bikeParking).addTo(map);
+      L.geoJSON(bikeParking).addTo(map);
     });
   });
 </script>

--- a/src/pages/examples/gp-plugin.hbs
+++ b/src/pages/examples/gp-plugin.hbs
@@ -50,6 +50,6 @@ layout: example.hbs
 
   function driveTimeCallback(error, response, raw){
     document.getElementById('info-pane').innerHTML = 'click on the map to calculate 1 and 2 minute drivetimes';
-    driveTimes.addLayer(L.geoJson(response.Output_Drive_Time_Polygons));
+    driveTimes.addLayer(L.geoJSON(response.Output_Drive_Time_Polygons));
   }
 </script>

--- a/src/pages/examples/identifying-features.hbs
+++ b/src/pages/examples/identifying-features.hbs
@@ -44,7 +44,7 @@ layout: example.hbs
     soil.identify().on(map).at(e.latlng).run(function(error, featureCollection){
       // make sure at least one feature was identified.
       if (featureCollection.features.length > 0) {
-        identifiedFeature = L.geoJson(featureCollection.features[0]).addTo(map);
+        identifiedFeature = L.geoJSON(featureCollection.features[0]).addTo(map);
         var soilDescription =
           featureCollection.features[0].properties['Dominant Order'] +
           ' - ' +

--- a/src/pages/examples/image-map-layer-mosaic-rule.hbs
+++ b/src/pages/examples/image-map-layer-mosaic-rule.hbs
@@ -15,7 +15,7 @@ layout: example.hbs
     var map = L.map('map').setView([30,0], 2);
 
     L.esri.imageMapLayer({
-      url: '//sampleserver3.arcgisonline.com/ArcGIS/rest/services/World/Temperature/ImageServer',
+      url: 'https://sampleserver3.arcgisonline.com/ArcGIS/rest/services/World/Temperature/ImageServer',
       mosaicRule: mosaicRule,
       useCors: false
     }).addTo(map);

--- a/src/pages/examples/image-map-layer-rendering-rule.hbs
+++ b/src/pages/examples/image-map-layer-rendering-rule.hbs
@@ -21,7 +21,7 @@ layout: example.hbs
     L.esri.basemapLayer('Imagery').addTo(map);
 
     L.esri.imageMapLayer({
-      url: '//sampleserver3.arcgisonline.com/ArcGIS/rest/services/Earthquakes/SanAndreasLidar/ImageServer',
+      url: 'https://sampleserver3.arcgisonline.com/ArcGIS/rest/services/Earthquakes/SanAndreasLidar/ImageServer',
       renderingRule: renderingRule,
       useCors: false
     }).addTo(map);

--- a/src/pages/examples/parse-feature-collection.hbs
+++ b/src/pages/examples/parse-feature-collection.hbs
@@ -31,7 +31,7 @@ layout: example.hbs
       featureCollection.features.push(feature);
     }
 
-    var geojson = L.geoJson(featureCollection).addTo(map);
+    var geojson = L.geoJSON(featureCollection).addTo(map);
     map.fitBounds(geojson.getBounds());
   });
 </script>

--- a/src/pages/examples/simple-image-map-layer.hbs
+++ b/src/pages/examples/simple-image-map-layer.hbs
@@ -10,6 +10,6 @@ layout: example.hbs
     var map = L.map('map').setView([37.75, -122.23], 10);
 
     L.esri.imageMapLayer({
-      url: '//imagery.arcgisonline.com/ArcGIS/rest/services/LandsatGLS/NaturalColor/ImageServer'
+      url: 'https://imagery.arcgisonline.com/ArcGIS/rest/services/LandsatGLS/NaturalColor/ImageServer'
     }).addTo(map);
 </script>

--- a/src/pages/examples/visualizing-time-on-image-layer.hbs
+++ b/src/pages/examples/visualizing-time-on-image-layer.hbs
@@ -48,7 +48,7 @@ layout: example.hbs
     L.esri.basemapLayer('GrayLabels').addTo(map);
 
     var vegetation = L.esri.imageMapLayer({
-        url: 'http://imagery.arcgisonline.com/arcgis/rest/services/LandsatGLS/NDVI_Colorized/ImageServer',
+        url: 'https://imagery.arcgisonline.com/arcgis/rest/services/LandsatGLS/NDVI_Colorized/ImageServer',
         useCors: false,
         layers: [0],
         // for some reason this service in particular sometimes redirects json requests to a bogus IP address

--- a/src/partials/header.hbs
+++ b/src/partials/header.hbs
@@ -44,8 +44,8 @@
     <script src="/js/linked/leaflet-dist/leaflet-src.js"></script>
     <script src="/js/linked/esri-leaflet-dist/esri-leaflet-debug.js"></script>
   {{else}}
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet-src.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.0.0/dist/leaflet-src.js"></script>
     <script src="https://unpkg.com/esri-leaflet@{{package.version}}"></script>
   {{/if}}
 


### PR DESCRIPTION
* use `L.geoJSON` casing consistently
* move a few imageMapLayers to explicit https.
* get rid of duplicate providers header in geosearch API ref page