### PR TITLE
Fix documentation on mapServiceProvider options

### DIFF
--- a/src/pages/api-reference/controls/geosearch.md
+++ b/src/pages/api-reference/controls/geosearch.md
@@ -174,7 +174,7 @@ Option | Type | Default | Description
 --- | --- | --- | ---
 `url` | `String` | *Required* | The URL for the service that will be searched.
 `searchFields` | `String` `Array[Strings]` | None | An array of fields to search for text.
-`layers` | `Array` | `0` | An array of layer identifiers to find text matches on. 
+`layers` | `Integer` `Array[Integers]` | `[0]` | An array of layer identifiers to find text matches on. 
 `formatSuggestion`| `Function` | See Description | Formatting function for the suggestion text. Receives feature information and returns a string.
 `bufferRadius` | `Integer` `Array[Integers]`| Buffer point results by this radius to create bounds.
 

--- a/src/pages/api-reference/controls/geosearch.md
+++ b/src/pages/api-reference/controls/geosearch.md
@@ -174,7 +174,7 @@ Option | Type | Default | Description
 --- | --- | --- | ---
 `url` | `String` | *Required* | The URL for the service that will be searched.
 `searchFields` | `String` `Array[Strings]` | None | An array of fields to search for text.
-`layer` | `Integer` | `0` | The layer to find text matches on. Can also be an array of layer identifiers.
+`layers` | `Array` | `0` | An array of layer identifiers to find text matches on. 
 `formatSuggestion`| `Function` | See Description | Formatting function for the suggestion text. Receives feature information and returns a string.
 `bufferRadius` | `Integer` `Array[Integers]`| Buffer point results by this radius to create bounds.
 


### PR DESCRIPTION
This tripped me up when I was reading the docs. There appears to be no `layer` option in the source code, only a `layers` option which takes an array of one or more layer ids.