### PR TITLE
bump to 2.0.4 and add more attribution disclaimers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esri-leaflet-doc",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": true,
   "author": "Patrick Arlt <parlt@esri.com> (http://patrickarlt.com)",
   "contributors": [

--- a/src/pages/api-reference/layers/dynamic-map-layer.md
+++ b/src/pages/api-reference/layers/dynamic-map-layer.md
@@ -36,7 +36,7 @@ Option | Type | Default | Description
 `format` | `String` | `'png24'` | Output format of the image.
 `transparent` | `Boolean` | `true` | Allow the server to produce transparent images.
 `f` | `String` | `'json'` |  Server response content type.
-`attribution` | `String` | `''` |  Attribution to include in Leaflet's default control.  The [copyright text](https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer) found in Service metadata is usually a good thing to reference.
+`attribution` | `String` | `''` |  Attribution from service metadata [copyright text](https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer) is automatically displayed in Leaflet's default control.  This property can be used for customization.
 `layers` | `Array` | `''` | An array of Layer IDs like `[3,4,5]` to show from the service.
 `layerDefs` | `String` `Object` | `''` | A string representing a query to run against the service before the image is rendered. This can be a string like `"STATE_NAME='Kansas' and POP2007>25000"` or an object mapping different queries to specific layers `{5:"STATE_NAME='Kansas'", 4:"STATE_NAME='Kansas'}`.
 `opacity` | `Number` | `1` | Opacity of the layer. Should be a value between 0 (completely transparent) and 1 (completely opaque).

--- a/src/pages/api-reference/layers/feature-layer.md
+++ b/src/pages/api-reference/layers/feature-layer.md
@@ -5,25 +5,23 @@ layout: documentation.hbs
 
 # {{page.data.title}}
 
-`L.esri.FeatureLayer` is used to visualize and query vector geographic data hosted in both ArcGIS Online and published using ArcGIS Server.
+`L.esri.FeatureLayer` is used to visualize, style, query and edit vector geographic data hosted in both ArcGIS Online and published using ArcGIS Server.  Copyright text from the service is added to map attribution automatically.
 
 Inherits from [L.Layer](http://leafletjs.com/reference-1.0.0.html#layer)
 
-Feature Layers are provided by Feature Services which can contain multiple layers. Feature Layers expose vector geographic information as a web service that can be visualized, styled, queried and edited.
-
-Here is a sample Feature Service URL
+Feature Layers reference an individual data source in either a parent [Map Service](http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Map_Service/02r3000000w2000000/) or [Feature Service](http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Feature_Service/02r3000000z2000000/) that can contain multiple layers.  You can see a sample Map Service URL below:
 
 ```
-https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Neighborhoods_pdx/
+http://sampleserver6.arcgisonline.com/arcgis/rest/services/Hurricanes/MapServer
 ```
 
-This particular service contains only one Feature Layer. Here is the Feature Layer URL
+This particular service includes two different data sources.  The URL for the 'Hurricane Tracks' feature layer will end in a number (representing its position among the other layers).
 
 ```
-https://services.arcgis.com/rOo16HdIMeOBI4Mb/ArcGIS/rest/services/Neighborhoods_pdx/FeatureServer/0
+http://sampleserver6.arcgisonline.com/arcgis/rest/services/Hurricanes/MapServer/1
 ```
 
-Note that the Feature Layer URL ends in `/FeatureServer/{LAYER_ID}`.
+**Feature Layer URLs always end in a number (ex: `/FeatureServer/{LAYER_ID}` or `/MapServer/{LAYER_ID}`).**
 
 You can create a new empty feature service with a single layer on the [ArcGIS for Developers website](https://developers.arcgis.com/en/hosted-data/#/new) or you can use ArcGIS Online to [create a Feature Service from a CSV or Shapefile](https://doc.arcgis.com/en/arcgis-online/share-maps/publish-features.htm).
 

--- a/src/pages/api-reference/layers/tiled-map-layer.md
+++ b/src/pages/api-reference/layers/tiled-map-layer.md
@@ -7,7 +7,9 @@ layout: documentation.hbs
 
 Inherits from [`L.TileLayer`](http://leafletjs.com/reference.html#tilelayer)
 
-Access tiles from ArcGIS Online and ArcGIS Server to visualize and identify features. If you have published a Feature Service in ArcGIS Online, it can be used to create a static set of tiles as well. You can find details about that process in the [ArcGIS Online Help](http://doc.arcgis.com/en/arcgis-online/share-maps/publish-tiles.htm#ESRI_SECTION1_F68FCBD33BD54117B23232D41A762E89).
+Access tiles from ArcGIS Online and ArcGIS Server to visualize and identify features. Copyright text from the service is added to map attribution automatically. 
+
+If you have published a Feature Service in ArcGIS Online, it can be used to create a static set of tiles as well. You can find details about that process in the [ArcGIS Online Help](http://doc.arcgis.com/en/arcgis-online/share-maps/publish-tiles.htm#ESRI_SECTION1_F68FCBD33BD54117B23232D41A762E89).
 
 > Your map service must be published using the Web Mercator Auxiliary Sphere tiling scheme (WKID 102100/3857) and the default scale options used by Google Maps, Bing Maps and [ArcGIS Online](http://resources.arcgis.com/en/help/arcgisonline-content/index.html#//011q00000002000000). Esri Leaflet will not support any other spatial reference for tile layers.
 
@@ -35,7 +37,7 @@ Access tiles from ArcGIS Online and ArcGIS Server to visualize and identify feat
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 |`url` | `String` | | *Required*: URL of the [Map Service](http://resources.arcgis.com/en/help/arcgis-rest-api/#/Map_Service/02r3000000w2000000) with a tile cache.
-| `zoomOffsetAllowance` | `Number` | `0.1` | If `correctZoomLevels` is enabled this controls the amount of tolerance if the difference at each scale level for remapping tile levels.
+| `zoomOffsetAllowance` | `Number` | `0.1` | If `correctZoomLevels` is enabled this controls the amount of tolerance for the difference at each scale level for remapping tile levels.
 | `proxy` | `String` | `false` | URL of an [ArcGIS API for JavaScript proxy](https://developers.arcgis.com/javascript/jshelp/ags_proxy.html) or [ArcGIS Resource Proxy](https://github.com/Esri/resource-proxy) to use for proxying requests. |
 | `useCors` | `Boolean` | `true` | Dictates if the service should use CORS when making GET requests. |
 | `token` | `String` | `null` | Will use this token to authenticate all calls to the service.

--- a/src/pages/download/index.md
+++ b/src/pages/download/index.md
@@ -23,7 +23,7 @@ All builds of Esri Leaflet are available for download on [GitHub](https://github
 
 ```xml
 <!-- ArcGIS Online Vector Basemaps -->
-<script src="https://unpkg.com/esri-leaflet-vector@1.0.0"></script>
+<script src="https://unpkg.com/esri-leaflet-vector@1.0.3"></script>
 
 <!-- Clustered Feature Layer -->
 <script src="https://unpkg.com/esri-leaflet-cluster@2.0.0"></script>

--- a/src/pages/tutorials/introduction-to-layer-types.md
+++ b/src/pages/tutorials/introduction-to-layer-types.md
@@ -8,15 +8,19 @@ layout: tutorials.hbs
 
 {{ page.data.description }}
 
+> Note: Copyright text from ArcGIS services are added to map attribution automatically. The [Terms of Use](https://github.com/esri/esri-leaflet#terms) for Esri hosted services apply to *all* Leaflet applications.
+
 ## Feature Layers
-A [Feature Layer](http://esri.github.io/esri-leaflet/api-reference/layers/feature-layer.html) involves pulling down the feature data for a particular layer in the JSON format from an ArcGIS Server instance to your web app. This means pulling down the information related to an individual feature such as its vertices as well as the attributes. Esri-Leaflet then takes the JSON data and renders it on your map.
+A [Feature Layer](http://esri.github.io/esri-leaflet/api-reference/layers/feature-layer.html) involves requesting feature attributes and geometry from ArcGIS Online or ArcGIS Server to display in your web app. Individual features are exposed to the developer as GeoJSON, whether the service fulfilling the request emits the format natively or not.
 
-Feature Layers are great because they contain all the attribute information which means additional operations such as creating popups are really easy beacuse the app already has all the information is needs. 
+Feature Layers are great because they contain all the attribute information, this makes things like creating popups really snappy because the client app already has all the information it needs. 
 
-The challenge with Feature Layers is that they can potentially require transferring large amounts of data from the server to the client. Because all the vertices and attributes are sent this means you may be requesting a really big JSON object containing each and every vertice for a complex set of polygons. For example you wouldn't want to use a Feature Layer if you were drawing draw tax parcels for the whole of the USA. To address this issue Esri-Leaflet provides a few options. Firstly by default Esri-Leaflet only requests the features within the current map extent meaning you're not requesting features that you probably don't need. Secondly Esri-Leaflet provides additional options to allows you to trim down the data size, these include only requesting specific attributes, generalizing geometries, or setting where clauses. However even after you've optimized your setup there will always be a limit to the amount of features which it makes sense to try and display clientside, this will be dependant on your particular service, browser and app.
+That said, Feature Layers can potentially transfer large amounts of data from the server to the client. For example you wouldn't want to use a Feature Layer if you were drawing draw tax parcels for the whole of the USA. To address this Esri Leaflet provides a few options. By default we only request features within the current map extent.  This allows you to extract a manageable number of a features from a service with lots of data on the back end.
+
+Esri Leaflet provides other mechanisms to optimize performance as well. You can control which attributes are fetched, generalizing geometry before it is downloaded and filter data using SQL clauses. However even after you've optimized your setup there will always be a limit to the amount of features which it makes sense to try and display clientside, this limit depends on the individual service, and the browser being used.
 
 ### How to consume Feature Layers from ArcGIS Server
-Feature Layers can be created in Esri-Leaflet from both `MapServer` or `FeatureServer` services published by ArcGIS Server. To utilise a `MapServer` service you need to specify a particular layer by appending the layer index, eg "ESRI_Population_World/MapServer*/0*".
+Feature Layers can be created in Esri Leaflet from both `MapServer` or `FeatureServer` services published by ArcGIS Server. To utilise a `MapServer` service you need to specify a particular layer by appending the layer index, eg "ESRI_Population_World/MapServer*/0*".
 
 So for example both of these are valid uses 
 ```js
@@ -48,7 +52,6 @@ When you request a feature layer from an ArcGIS Server the response will look so
 }
 ```
 You can see in the above sample that we have some location information in the `coordinates` array as well as the feature properties in the `properties` object.
-
 
 ## Dynamic Map Layers
 A [Dynamic Map Layer](http://esri.github.io/esri-leaflet/api-reference/layers/dynamic-map-layer.html) involves pulling down a representation of your data from an ArcGIS Server instance to your web app, this means an image such as a jpg or a png. Esri-Leaflet then takes care of placing the image on the correct part of the map for you.
@@ -90,6 +93,7 @@ L.esri.tiledMapLayer({
 ```
 
 ### What does the data look like?
-When you request a Tiled Map Layer from an ArcGIS Server the response might look something like
+You can see an example Tiled Map Layer response from ArcGIS Server below. It is simply an image!
+
 ![Map tile](http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/PublicSafety/PublicSafetyBasemap/MapServer/tile/6/146/267)
-As you can see, it is simply an image!
+


### PR DESCRIPTION
* improved wording in feature layer api reference
* made copyedits to 'intro to layer types' tutorial
* bumped esri-leaflet version in samples to `2.0.4`