### PR TITLE
fix/bump editing sample

### DIFF
--- a/src/pages/examples/editing.hbs
+++ b/src/pages/examples/editing.hbs
@@ -41,8 +41,6 @@ layout: example.hbs
   </form>
 </div>
 <script>
-  // to do, ensure that feature click stops event propogation from trickling down to map
-
   // create the map
   var map = L.map('map').setView([45.512, -122.619], 12);
   L.esri.basemapLayer('Streets').addTo(map);

--- a/src/pages/examples/editing.hbs
+++ b/src/pages/examples/editing.hbs
@@ -5,8 +5,8 @@ layout: example.hbs
 ---
 
 <!-- Leaflet Draw -->
-<script src="//rawgit.com/Leaflet/Leaflet.draw/master/dist/leaflet.draw-src.js"></script>
-<link rel="stylesheet" href="//rawgit.com/Leaflet/Leaflet.draw/master/dist/leaflet.draw.css">
+<script src="https://unpkg.com/leaflet-draw@0.4.7/dist/leaflet.draw-src.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/leaflet-draw@0.4.7/dist/leaflet.draw-src.css">
 
 <style>
   #info-pane {
@@ -41,6 +41,8 @@ layout: example.hbs
   </form>
 </div>
 <script>
+  // to do, ensure that feature click stops event propogation from trickling down to map
+
   // create the map
   var map = L.map('map').setView([45.512, -122.619], 12);
   L.esri.basemapLayer('Streets').addTo(map);
@@ -117,6 +119,8 @@ layout: example.hbs
     if (!currentlyDeleting) {
       displayAttributes();
     }
+    // make sure map click event isn't fired. (seems like a bug)
+    L.DomEvent.stopPropagation(e);
   });
 
   // when pedestrian districts start loading (because of pan/zoom) stop editing

--- a/src/partials/sidebar-examples.hbs
+++ b/src/partials/sidebar-examples.hbs
@@ -23,9 +23,7 @@
     <a href="{{assets}}examples/zooming-to-all-features-2.html">Zoom to all Features #2</a>
     <a href="{{assets}}examples/labeling-features.html">Labeling Features</a>
     <a href="{{assets}}examples/layer-ordering.html">Ordering Layers</a>
-
-
-    <!--<a href="{{assets}}examples/editing.html">Editing</a>-->
+    <a href="{{assets}}examples/editing.html">Editing</a>
   </nav>
 
   <h5>Feature Layer Plugins</h5>


### PR DESCRIPTION
resolves #15

* bumped Leaflet.draw source link to use a tagged version instead of pointing at `master`
* added manual call to stop event propogation when someone clicks on a feature so that the map click listener isn't triggered too.