### PR TITLE
bump geocoder to 2.2.2 (in one place instead of 4)

### DIFF
--- a/data/siteData.json
+++ b/data/siteData.json
@@ -1,4 +1,7 @@
 {
   "isDev": true,
-  "localSource": false
+  "localSource": false,
+  "version": "2.0.6",
+  "leaflet-version": "1.0.2",
+  "geocoder-version": "2.2.2"
 }

--- a/src/layouts/example.hbs
+++ b/src/layouts/example.hbs
@@ -21,12 +21,16 @@ layout: page.hbs
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
 
   <!-- Load Leaflet from CDN-->
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.2/dist/leaflet.css" />
-  <script src="https://unpkg.com/leaflet@1.0.2/dist/leaflet-src.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@{{siteData.leaflet-version}}/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@{{siteData.leaflet-version}}/dist/leaflet-src.js"></script>
 
   <!-- Load Esri Leaflet from CDN -->
-  <script src="https://unpkg.com/esri-leaflet@{{package.version}}"></script>
-
+  <script src="https://unpkg.com/esri-leaflet@{{siteData.version}}"></script>
+  {{#if page.data.geocoder}}
+  <!-- Load Esri Leaflet Geocoder from CDN -->
+  <link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@{{siteData.geocoder-version}}/dist/esri-leaflet-geocoder.css">
+  <script src="https://unpkg.com/esri-leaflet-geocoder@{{siteData.geocoder-version}}"></script>
+  {{/if}}
   <style>
     body { margin:0; padding:0; }
     #map { position: absolute; top:0; bottom:0; right:0; left:0; }

--- a/src/pages/api-reference/layers/dynamic-map-layer.md
+++ b/src/pages/api-reference/layers/dynamic-map-layer.md
@@ -41,6 +41,8 @@ Option | Type | Default | Description
 `layerDefs` | `String` `Object` | `''` | A string representing a query to run against the service before the image is rendered. This can be a string like `"3:STATE_NAME='Kansas'"` or an object mapping different queries to specific layers `{3:"STATE_NAME='Kansas'", 2:"POP2007>25000"}`.
 `opacity` | `Number` | `1` | Opacity of the layer. Should be a value between 0 (completely transparent) and 1 (completely opaque).
 `position` | `String` | `'front'` | Position of the layer relative to other overlays.
+`maxZoom` | `Number` | | Closest zoom level the layer will be displayed on the map.
+`minZoom` | `Number` | | Furthest zoom level the layer will be displayed on the map.
 `dynamicLayers` | `Object` | `null` | JSON object literal used to manipulate the layer symbology defined in the service itself.  Requires a 10.1 (or above) map service which supports [dynamicLayers](http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Export_Map/02r3000000v7000000/) requests.
 `token` | `String` | `null` | If you pass a token in your options it will be included in all requests to the service.
 `proxy` | `String` | `false` | URL of an [ArcGIS API for JavaScript proxy](https://developers.arcgis.com/javascript/jshelp/ags_proxy.html) or [ArcGIS Resource Proxy](https://github.com/Esri/resource-proxy) to use for proxying POST requests.

--- a/src/pages/api-reference/layers/feature-layer.md
+++ b/src/pages/api-reference/layers/feature-layer.md
@@ -81,14 +81,14 @@ You can create a new empty feature service with a single layer on the [ArcGIS fo
             <td>An optional expression to filter features server side. String values should be denoted using single quotes ie: `where: "FIELDNAME = 'field value'";` More information about valid SQL syntax can be found <a href="http://resources.arcgis.com/en/help/main/10.2/index.html#/SQL_reference_for_query_expressions_used_in_ArcGIS/00s500000033000000/">here</a>.</td>
         </tr>
         <tr>
-            <td><code>minZoom</code></td>
-            <td><code>Integer</code></td>
-            <td>Minimum zoom level of the map that features will display. example:  <code>minZoom:0</code></td>
+            <td><code>maxZoom</code></td>
+            <td><code>Number</code></td>
+            <td>Closest zoom level the layer will be displayed on the map. example:  <code>maxZoom:19</code></td>
         </tr>
         <tr>
-            <td><code>maxZoom</code></td>
-            <td><code>Integer</code></td>
-            <td>Maximum zoom level of the map that features will display. example:  <code>maxZoom:19</code></td>
+            <td><code>minZoom</code></td>
+            <td><code>Number</code></td>
+            <td>Furthest zoom level the layer will be displayed on the map. example:  <code>maxZoom:3</code></td>
         </tr>
         <tr>
             <td><code>cacheLayers</code></td>
@@ -122,8 +122,8 @@ You can create a new empty feature service with a single layer on the [ArcGIS fo
         </tr>
         <tr>
             <td><code>simplifyFactor</code></td>
-            <td><code>Integer</code></td>
-            <td>How much to simplify polygons and polylines. More means better performance, and less means more accurate representation.</td>
+            <td><code>Number</code></td>
+            <td>How much to simplify polygons and polylines. A higher value gives better performance, a lower value gives a more accurate representation.</td>
         </tr>
         <tr>
             <td><code>precision</code></td>

--- a/src/pages/api-reference/layers/image-map-layer.md
+++ b/src/pages/api-reference/layers/image-map-layer.md
@@ -37,15 +37,18 @@ Option | Type | Default | Description
 `f` | `String` | `'image'` | Server response content type.
 `opacity` | `Number` | `1` | Opacity of the layer. Should be a value between 0 and 1.
 `position` | `String` | `'front'` | Position of the layer relative to other overlays.
-`proxy` | `String` | `false` | URL of an [ArcGIS API for JavaScript proxies](https://developers.arcgis.com/javascript/jshelp/ags_proxy.html) or [ArcGIS Resource Proxies](https://github.com/Esri/resource-proxy) to use for proxying POST requests.
+`maxZoom` | `Number` | | Closest zoom level the layer will be displayed on the map.
+`minZoom` | `Number` | | Furthest zoom level the layer will be displayed on the map.
 `bandIds` | `String` | `undefined` | If there are multiple bands, you can specify which bands to export.
 `noData` | `Number` | `undefined` | The pixel value representing no information.
 `noDataInterpretation` | `String` | `undefined` | Interpretation of the `noData` setting.
 `pixelType` | `String` | `undefined` | Leave `pixelType` as unspecified, or `UNKNOWN`, in most exportImage use cases, unless such `pixelType` is desired. Possible values: `C128`, `C64`, `F32`, `F64`, `S16`, `S32`, `S8`, `U1`, `U16`, `U2`, `U32`, `U4`, `U8`, `UNKNOWN`.
-`useCors` | `Boolean` | `true` | If this service should use CORS when making GET requests.
 `renderingRule` | `Object` | `undefined` | A JSON representation of a [raster function](http://resources.arcgis.com/en/help/arcgis-rest-api/#/Raster_function_objects/02r3000000rv000000/)
 `mosaicRule` | `Object` | `undefined` | A JSON representation of a [mosaic rule](http://resources.arcgis.com/en/help/arcgis-rest-api/#/Mosaic_rule_objects/02r3000000s4000000/)
 `pane` | `String` | `overlayPane` | The map pane to render on.
+`token` | `String` | `null` | If you pass a token in your options it will be included in all requests to the service.
+`proxy` | `String` | `false` | URL of an [ArcGIS API for JavaScript proxies](https://developers.arcgis.com/javascript/jshelp/ags_proxy.html) or [ArcGIS Resource Proxies](https://github.com/Esri/resource-proxy) to use for proxying POST requests.
+`useCors` | `Boolean` | `true` | If this service should use CORS when making GET requests.
 
 ### Methods
 

--- a/src/pages/api-reference/layers/raster-layer.md
+++ b/src/pages/api-reference/layers/raster-layer.md
@@ -14,6 +14,8 @@ Option | Type | Default | Description
 `f` | `String` | `'image'` |  Server response content type.
 `opacity` | `Number` | `1` | Opacity of the layer. Should be a value between 0 and 1.
 `position` | `String` | `'front'` | Position of the layer relative to other overlays.
+`maxZoom` | `Number` | | Closest zoom level the layer will be displayed on the map.
+`minZoom` | `Number` | | Furthest zoom level the layer will be displayed on the map.
 
 ### Methods
 

--- a/src/pages/examples/geocoding-control.hbs
+++ b/src/pages/examples/geocoding-control.hbs
@@ -2,10 +2,8 @@
 title: Geocoding control
 description: Using the geocoding control to search for addresses and center the map. This demo relies of the <a href="https://github.com/Esri/esri-leaflet-geocoder">Esri Leaflet Geocoder</a> plugin.
 layout: example.hbs
+geocoder: true
 ---
-
-<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.2.1/dist/esri-leaflet-geocoder.css">
-<script src="https://unpkg.com/esri-leaflet-geocoder@2.2.1"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/reverse-geocoding.hbs
+++ b/src/pages/examples/reverse-geocoding.hbs
@@ -2,10 +2,8 @@
 title: Reverse geocoding
 description: Query the closest address to a given point with the Esri Leaflet Geocoder plugin. Click to show the closest street address to the clicked point. This demo relies of the <a href="https://github.com/Esri/esri-leaflet-geocoder">Esri Leaflet Geocoder</a> plugin.
 layout: example.hbs
+geocoder: true
 ---
-
-<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.2.1/dist/esri-leaflet-geocoder.css">
-<script src="https://unpkg.com/esri-leaflet-geocoder@2.2.1"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/search-feature-layer.hbs
+++ b/src/pages/examples/search-feature-layer.hbs
@@ -2,10 +2,8 @@
 title: Searching feature layers
 description: Searches features layers for matching text in addition to geocoding. This demo relies of the <a href="https://github.com/Esri/esri-leaflet-geocoder">Esri Leaflet Geocoder</a> plugin.
 layout: example.hbs
+geocoder: true
 ---
-
-<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.2.1/dist/esri-leaflet-geocoder.css">
-<script src="https://unpkg.com/esri-leaflet-geocoder@2.2.1"></script>
 
 <div id="map"></div>
 

--- a/src/pages/examples/search-map-service.hbs
+++ b/src/pages/examples/search-map-service.hbs
@@ -2,10 +2,8 @@
 title: Searching map services
 description: In addition to geocoding addresses and points of interest, you can also search features in map services for matching text. This demo relies of the <a href="https://github.com/Esri/esri-leaflet-geocoder">Esri Leaflet Geocoder</a> plugin.
 layout: example.hbs
+geocoder: true
 ---
-
-<link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.2.1/dist/esri-leaflet-geocoder.css">
-<script src="https://unpkg.com/esri-leaflet-geocoder@2.2.1"></script>
 
 <div id="map"></div>
 

--- a/src/partials/header.hbs
+++ b/src/partials/header.hbs
@@ -35,7 +35,6 @@
   {{#if siteData.isDev}}
     <!-- 'livereload' for development -->
     <script src="//localhost:35729/livereload.js"></script>
-  {{else}}
   {{/if}}
 
   {{#if siteData.localSource}}
@@ -44,9 +43,14 @@
     <script src="/js/linked/leaflet-dist/leaflet-src.js"></script>
     <script src="/js/linked/esri-leaflet-dist/esri-leaflet-debug.js"></script>
   {{else}}
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.2/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.0.2/dist/leaflet-src.js"></script>
-    <script src="https://unpkg.com/esri-leaflet@{{package.version}}"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@{{siteData.leaflet-version}}/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@{{siteData.leaflet-version}}/dist/leaflet-src.js"></script>
+    <script src="https://unpkg.com/esri-leaflet@{{siteData.version}}"></script>
+  {{/if}}
+
+  {{#if page.data.geocoder}}
+    <link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@{{siteData.geocoder-version}}/dist/esri-leaflet-geocoder.css">
+    <script src="https://unpkg.com/esri-leaflet-geocoder@{{siteData.geocoder-version}}"></script>
   {{/if}}
 
   <!-- Google Analytics -->


### PR DESCRIPTION
DRYed up the code a bit.

now we can update the version number in `data/siteData.json` to bump the version used *and* displayed in markdown in **all** examples.

applies to
* leaflet
* esri-leaflet
* esri-leaflet-geocoder

also improved the wording describing both `minZoom` and `maxZoom`. lots of folks (myself included) have a hard time remembering which refers to smaller scales and which refers to bigger scales.