### PR TITLE
move supplemental version numbers into package.json

### DIFF
--- a/data/siteData.json
+++ b/data/siteData.json
@@ -1,7 +1,4 @@
 {
   "isDev": true,
-  "localSource": false,
-  "version": "2.0.6",
-  "leaflet-version": "1.0.2",
-  "geocoder-version": "2.2.2"
+  "localSource": false
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esri-leaflet-doc",
-  "version": "2.0.6",
+  "version": "1.0.0",
   "private": true,
   "author": "Patrick Arlt <parlt@esri.com> (http://patrickarlt.com)",
   "contributors": [
@@ -28,6 +28,11 @@
   "repository": {
     "type": "git",
     "url": "git@github.com:Esri/esri-leaflet-doc.git"
+  },
+  "sample-versions": {
+    "leaflet": "1.0.2",
+    "esri-leaflet": "2.0.6",
+    "esri-leaflet-geocoder": "2.2.2"
   },
   "scripts": {
     "start": "grunt"

--- a/src/layouts/example.hbs
+++ b/src/layouts/example.hbs
@@ -21,15 +21,15 @@ layout: page.hbs
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
 
   <!-- Load Leaflet from CDN-->
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@{{siteData.leaflet-version}}/dist/leaflet.css" />
-  <script src="https://unpkg.com/leaflet@{{siteData.leaflet-version}}/dist/leaflet-src.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@{{package.sample-versions.leaflet}}/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@{{package.sample-versions.leaflet}}/dist/leaflet-src.js"></script>
 
   <!-- Load Esri Leaflet from CDN -->
-  <script src="https://unpkg.com/esri-leaflet@{{siteData.version}}"></script>
+  <script src="https://unpkg.com/esri-leaflet@{{package.sample-versions.esri-leaflet}}"></script>
   {{#if page.data.geocoder}}
   <!-- Load Esri Leaflet Geocoder from CDN -->
-  <link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@{{siteData.geocoder-version}}/dist/esri-leaflet-geocoder.css">
-  <script src="https://unpkg.com/esri-leaflet-geocoder@{{siteData.geocoder-version}}"></script>
+  <link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@{{package.sample-versions.esri-leaflet-geocoder}}/dist/esri-leaflet-geocoder.css">
+  <script src="https://unpkg.com/esri-leaflet-geocoder@{{package.sample-versions.esri-leaflet-geocoder}}"></script>
   {{/if}}
   <style>
     body { margin:0; padding:0; }

--- a/src/partials/header.hbs
+++ b/src/partials/header.hbs
@@ -43,14 +43,14 @@
     <script src="/js/linked/leaflet-dist/leaflet-src.js"></script>
     <script src="/js/linked/esri-leaflet-dist/esri-leaflet-debug.js"></script>
   {{else}}
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@{{siteData.leaflet-version}}/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@{{siteData.leaflet-version}}/dist/leaflet-src.js"></script>
-    <script src="https://unpkg.com/esri-leaflet@{{siteData.version}}"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@{{package.sample-versions.leaflet}}/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@{{package.sample-versions.leaflet}}/dist/leaflet-src.js"></script>
+    <script src="https://unpkg.com/esri-leaflet@{{package.sample-versions.esri-leaflet}}"></script>
   {{/if}}
 
   {{#if page.data.geocoder}}
-    <link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@{{siteData.geocoder-version}}/dist/esri-leaflet-geocoder.css">
-    <script src="https://unpkg.com/esri-leaflet-geocoder@{{siteData.geocoder-version}}"></script>
+    <link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@{{package.sample-versions.esri-leaflet-geocoder}}/dist/esri-leaflet-geocoder.css">
+    <script src="https://unpkg.com/esri-leaflet-geocoder@{{package.sample-versions.esri-leaflet-geocoder}}"></script>
   {{/if}}
 
   <!-- Google Analytics -->


### PR DESCRIPTION
when i pushed the changes from #124 into production i realized that 'siteData.json' is only utilized by [`assemble:dev`](https://github.com/Esri/esri-leaflet-doc/blob/ba0dd4d51e9bdc9d779392ced3490a518dd94bca/Gruntfile.js#L59).

because of this, i decided to store the variables in a custom 'package.json' tag instead.