### PR TITLE
bump to leaflet 1.0.3 in live samples

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "git@github.com:Esri/esri-leaflet-doc.git"
   },
   "sample-versions": {
-    "leaflet": "1.0.2",
+    "leaflet": "1.0.3",
     "esri-leaflet": "2.0.7",
     "esri-leaflet-geocoder": "2.2.3",
     "esri-leaflet-vector": "1.0.6"

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -10,6 +10,8 @@ var bgmap = L.map('background-map', {
     layers: [L.esri.basemapLayer('Topographic')]
 });
 
+bgmap.setView([68.41, -179], 10, {animate: true, pan: {duration: 100000}})
+
 if (map) {
   map.scrollWheelZoom.disable();
   map.once("click", accidentalScroll, map);

--- a/src/pages/api-reference/tasks/query.md
+++ b/src/pages/api-reference/tasks/query.md
@@ -68,12 +68,12 @@ layout: documentation.hbs
         <tr>
             <td><code>overlap({{{param 'Geometry' 'geometry'}}})</code></td>
             <td><code>this</code></td>
-            <td>Queries features from the service that overlap (touch but are not fully contained by) the passed geometry object. `geometry` can be an instance of [`L.Marker`](http://leafletjs.com/reference.html#marker), [`L.Polygon`](http://leafletjs.com/reference.html#polygon), [`L.Polyline`](http://leafletjs.com/reference.html#polyline), [`L.LatLng`](http://leafletjs.com/reference.html#latlng), [`L.LatLngBounds`](http://leafletjs.com/reference.html#latlngbounds) and [`L.GeoJSON`](http://leafletjs.com/reference.html#geojson). It can also accept valid GeoJSON [Point](http://geojson.org/geojson-spec.html#point), [Polyline](http://geojson.org/geojson-spec.html#polyline), [Polygon](http://geojson.org/geojson-spec.html#polygon) objects and GeoJSON [Feature objects](http://geojson.org/geojson-spec.html#feature-objects) objects containing Point, Polyline, Polygon.</td>
+            <td>Queries features from the service that overlap (touch but are not fully contained by) the passed geometry object. `geometry` can be an instance of [`L.Marker`](http://leafletjs.com/reference.html#marker), [`L.Polygon`](http://leafletjs.com/reference.html#polygon), [`L.Polyline`](http://leafletjs.com/reference.html#polyline), [`L.LatLng`](http://leafletjs.com/reference.html#latlng), [`L.LatLngBounds`](http://leafletjs.com/reference.html#latlngbounds) and [`L.GeoJSON`](http://leafletjs.com/reference.html#geojson). It can also accept valid GeoJSON [Point](http://geojson.org/geojson-spec.html#point), [Polyline](http://geojson.org/geojson-spec.html#polyline), [Polygon](http://geojson.org/geojson-spec.html#polygon) objects and GeoJSON [Feature objects](http://geojson.org/geojson-spec.html#feature-objects) containing Point, Polyline, Polygon.</td>
         </tr>
         <tr>
             <td><code>nearby({{{param 'LatLng' 'latlng' 'http://leafletjs.com/reference.html#latlng'}}}, {{{param 'Integer' 'distance'}}})</code></td>
             <td><code>this</code></td>
-            <td>Queries features a given distance in meters around a <a href="http://leafletjs.com/reference.html#latlng">LatLng</a>. <small>Only available for Feature Layers hosted on ArcGIS Online or ArcGIS Server 10.3 that include the capability <code>supportQueryWithDistance</code>.</small></td>
+            <td>Queries features a given distance in meters around a <a href="http://leafletjs.com/reference.html#latlng">LatLng</a>. <br><small>Only available for Feature Layers hosted on ArcGIS Online or ArcGIS Server 10.3 that include the capability <code>supportQueryWithDistance</code>.</small></td>
         </tr>
         <tr>
             <td><code>where({{{param 'String' 'where'}}})</code></td>
@@ -83,12 +83,12 @@ layout: documentation.hbs
         <tr>
             <td><code>offset({{{param 'Integer' 'offset'}}})</code></td>
             <td><code>this</code></td>
-            <td>Define the offset of the results, when combined with `limit` can be used for paging. <small>Only available for Feature Layers hosted on ArcGIS Online or ArcGIS Server 10.3.</small></td>
+            <td>Define the offset of the results, when combined with `limit` can be used for paging. <br><small>Only available for Feature Layers hosted on ArcGIS Online or ArcGIS Server 10.3.</small></td>
         </tr>
         <tr>
             <td><code>limit({{{param 'Integer' 'limit'}}})</code></td>
             <td><code>this</code></td>
-            <td>Limit the number of results returned by this query, when combined with `offset` can be used for paging. <small>Only available for Feature Layers hosted on ArcGIS Online or ArcGIS Server 10.3.</small></td>
+            <td>Limit the number of results returned by this query, when combined with `offset` can be used for paging. <br><small>Only available for Feature Layers hosted on ArcGIS Online or ArcGIS Server 10.3.</small></td>
         </tr>
         <tr>
             <td><code>between({{{param 'Date' 'from'}}}, {{{param 'Date' 'to'}}})</code></td>

--- a/src/pages/examples/simple-image-map-layer.hbs
+++ b/src/pages/examples/simple-image-map-layer.hbs
@@ -10,6 +10,7 @@ layout: example.hbs
     var map = L.map('map').setView([37.75, -122.23], 10);
 
     L.esri.imageMapLayer({
-      url: 'http://imagery.arcgisonline.com/ArcGIS/rest/services/LandsatGLS/NaturalColor/ImageServer'
+      url: 'https://landsat.arcgis.com/arcgis/rest/services/Landsat/PS/ImageServer',
+      attribution: 'United States Geological Survey (USGS), National Aeronautics and Space Administration (NASA)'
     }).addTo(map);
 </script>

--- a/src/pages/examples/simple-image-map-layer.hbs
+++ b/src/pages/examples/simple-image-map-layer.hbs
@@ -10,6 +10,6 @@ layout: example.hbs
     var map = L.map('map').setView([37.75, -122.23], 10);
 
     L.esri.imageMapLayer({
-      url: 'https://imagery.arcgisonline.com/ArcGIS/rest/services/LandsatGLS/NaturalColor/ImageServer'
+      url: 'http://imagery.arcgisonline.com/ArcGIS/rest/services/LandsatGLS/NaturalColor/ImageServer'
     }).addTo(map);
 </script>

--- a/src/pages/examples/visualizing-time-on-image-layer.hbs
+++ b/src/pages/examples/visualizing-time-on-image-layer.hbs
@@ -48,7 +48,7 @@ layout: example.hbs
     L.esri.basemapLayer('GrayLabels').addTo(map);
 
     var vegetation = L.esri.imageMapLayer({
-        url: 'https://imagery.arcgisonline.com/arcgis/rest/services/LandsatGLS/NDVI_Colorized/ImageServer',
+        url: 'http://imagery.arcgisonline.com/arcgis/rest/services/LandsatGLS/NDVI_Colorized/ImageServer',
         useCors: false,
         layers: [0],
         // for some reason this service in particular sometimes redirects json requests to a bogus IP address

--- a/src/pages/examples/visualizing-time-on-image-layer.hbs
+++ b/src/pages/examples/visualizing-time-on-image-layer.hbs
@@ -1,6 +1,6 @@
 ---
 title: Time Ranges
-description: Select a date between 1990 and 2010 to fetch appropriate imagery from an Image Service.  More information about Image Services can be found in the <a href="../api-reference/layers/image-map-layer.html">L.esri.ImageMapLayer</a> documentation.
+description: Select a snapshot between 1990 and 2010 to fetch Landsat bands; 4,3,2. More information about ImageMapLayers can be found in the <a href="../api-reference/layers/image-map-layer.html">L.esri.ImageMapLayer</a> documentation.
 layout: example.hbs
 ---
 
@@ -32,6 +32,7 @@ layout: example.hbs
             <select id='timeInput' type="date" name='date'>
                 <option>1990</option>
                 <option>2000</option>
+                <option>2005</option>
                 <option>2010</option>
             </select>
         </label>
@@ -44,15 +45,11 @@ layout: example.hbs
 
     var map = L.map('map').setView([-12.604858, -55.947675], 9);
 
-    L.esri.basemapLayer('Gray').addTo(map);
-    L.esri.basemapLayer('GrayLabels').addTo(map);
-
     var vegetation = L.esri.imageMapLayer({
-        url: 'http://imagery.arcgisonline.com/arcgis/rest/services/LandsatGLS/NDVI_Colorized/ImageServer',
-        useCors: false,
-        layers: [0],
-        // for some reason this service in particular sometimes redirects json requests to a bogus IP address
-        f: 'image',
+        url: 'https://landsat.arcgis.com/arcgis/rest/services/LandsatGLS/MS/ImageServer',
+        attribution: 'United States Geological Survey (USGS), National Aeronautics and Space Administration (NASA)',
+        bandIds: "4,3,2",
+        // renderingRule: { "rasterFunction":"NDVI Colorized" },
         from: new Date(timeInput.value),
         to: new Date(timeInput.value)
     }).addTo(map);

--- a/src/scss/base/_layout.scss
+++ b/src/scss/base/_layout.scss
@@ -28,8 +28,8 @@ body {
   display: inline-block;
   margin: 0 1em;
   font-size: 1rem;
-  color: $white;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.75);
+  color: #4C5156;
+  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.75);
   letter-spacing: 1px;
   font-weight: 700;
   &:hover {
@@ -74,15 +74,15 @@ body {
     opacity: .35;
   }
   &.leaflet-container {
-    background-color: rgba(36, 132, 210, 0.85);
+    background-color: rgba(36, 132, 210, 0.35);
     -webkit-animation-iteration-count: infinite;
-    -webkit-animation-duration: 120s;
+    -webkit-animation-duration: 30s;
     -webkit-animation-name: colorshift;
     -moz-animation-iteration-count: infinite;
-    -moz-animation-duration: 120s;
+    -moz-animation-duration: 30s;
     -moz-animation-name: colorshift;
     animation-iteration-count: infinite;
-    animation-duration: 120s;
+    animation-duration: 30s;
     animation-name: colorshift;
   }
 }
@@ -95,36 +95,36 @@ body {
 
 @keyframes colorshift {
   0% {
-    background-color: rgba(36, 132, 210, 0.85);
+    background-color: rgba(36, 132, 210, 0.25);
   }
   33% {
-    background-color: rgba(121, 189, 143, 0.85);
+    background-color: rgba(121, 189, 143, 0.25);
   }
   66% {
-    background-color: rgba(157, 120, 210, 0.85);
+    background-color: rgba(157, 120, 210, 0.25);
   }
 }
 
 @-webkit-keyframes colorshift {
   0% {
-    background-color: rgba(36, 132, 210, 0.85);
+    background-color: rgba(36, 132, 210, 0.25);
   }
   33% {
-    background-color: rgba(121, 189, 143, 0.85);
+    background-color: rgba(121, 189, 143, 0.25);
   }
   66% {
-    background-color: rgba(157, 120, 210, 0.85);
+    background-color: rgba(157, 120, 210, 0.25);
   }
 }
 
 @-moz-keyframes colorshift {
   0% {
-    background-color: rgba(36, 132, 210, 0.85);
+    background-color: rgba(36, 132, 210, 0.25);
   }
   33% {
-    background-color: rgba(121, 189, 143, 0.85);
+    background-color: rgba(121, 189, 143, 0.25);
   }
   66% {
-    background-color: rgba(157, 120, 210, 0.85);
+    background-color: rgba(157, 120, 210, 0.25);
   }
 }


### PR DESCRIPTION
* substituted http links for two imageMapLayer samples because of ssl trouble on the server
* stole an idea from the late great @nikolaswise
* made the background mask more transparent
* sped up the color transition
* switched to dark nav text
* fixed a typo in the query api ref