### PR TITLE
Remove background map pan animation

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -10,8 +10,6 @@ var bgmap = L.map('background-map', {
     layers: [L.esri.basemapLayer('Topographic')]
 });
 
-bgmap.setView([68.41, -179], 10, {animate: true, pan: {duration: 100000}})
-
 if (map) {
   map.scrollWheelZoom.disable();
   map.once("click", accidentalScroll, map);


### PR DESCRIPTION
I like the effect of a slowly moving map in background... Just seems browser's don't like executing the effect very much :(