### PR TITLE
new Leaflet.Editable sample (and legacy flag)

### DIFF
--- a/src/layouts/example.hbs
+++ b/src/layouts/example.hbs
@@ -20,6 +20,11 @@ layout: page.hbs
   <title>{{page.data.title}}</title>
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
 
+  {{#if page.data.legacy}}
+  <!-- Load Leaflet from CDN-->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css"/>
+  <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet-src.js"></script>
+  {{else}}
   <!-- Load Leaflet from CDN-->
   <link rel="stylesheet" href="https://unpkg.com/leaflet@{{package.sample-versions.leaflet}}/dist/leaflet.css"
     integrity="sha512-wcw6ts8Anuw10Mzh9Ytw4pylW8+NAD4ch3lqm9lzAsTxg0GFeJgoAtxuCLREZSC5lUXdVyo/7yfsqFjQ4S+aKw=="
@@ -27,6 +32,7 @@ layout: page.hbs
   <script src="https://unpkg.com/leaflet@{{package.sample-versions.leaflet}}/dist/leaflet-src.js"
     integrity="sha384-TWB9xRHTlLQmqAngHwD7usGcf4akGf0JP6aHwlgilpmOu2UuBq5aWLsDAh39iSn1"
     crossorigin=""></script>
+  {{/if}}
 
   <!-- Load Esri Leaflet from CDN -->
   <script src="https://unpkg.com/esri-leaflet@{{package.sample-versions.esri-leaflet}}"

--- a/src/pages/examples/editable.hbs
+++ b/src/pages/examples/editable.hbs
@@ -1,0 +1,98 @@
+---
+title: Editing feature layers
+description: This sample uses the Leaflet <a href="//github.com/Leaflet/Leaflet.Editable">Editable plugin</a> to help users manipulate the geometry of features from a hosted feature service and pass the edits back to the server.
+
+layout: example.hbs
+legacy: true
+
+---
+<script src="https://unpkg.com/leaflet.path.drag@0.0.5"></script>
+<script src="https://unpkg.com/leaflet-editable@1.0.0"></script>
+
+<div id='map'></div>
+
+<script type="text/javascript">
+    // make sure double clicking the map *only* triggers the editing workflow
+    var map = L.map('map', {
+      editable: true,
+      doubleClickZoom: false
+    }).setView([45.512, -122.619], 12);
+
+    var tilelayer = L.esri.basemapLayer("Topographic").addTo(map);
+
+    // create a feature layer and add it to the map
+    var pedestrianDistricts = L.esri.featureLayer({
+      url: 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/PDX_Pedestrian_Districts/FeatureServer/0'
+    }).addTo(map);
+
+    // create a generic control to invoke editing
+    L.EditControl = L.Control.extend({
+        options: {
+            position: 'topleft',
+            callback: null,
+            kind: '',
+            html: ''
+        },
+        // when the control is added to the map, wire up its DOM dynamically and add a click listener
+        onAdd: function (map) {
+            var container = L.DomUtil.create('div', 'leaflet-control leaflet-bar'),
+                link = L.DomUtil.create('a', '', container);
+            link.href = '#';
+            link.title = 'Create a new ' + this.options.kind;
+            link.innerHTML = this.options.html;
+            L.DomEvent.on(link, 'click', L.DomEvent.stop)
+                      .on(link, 'click', function () {
+                        window.LAYER = this.options.callback.call(map.editTools);
+                      }, this);
+            return container;
+        }
+    });
+
+    // extend the control to draw polygons
+    L.NewPolygonControl = L.EditControl.extend({
+        options: {
+            position: 'topleft',
+            callback: map.editTools.startPolygon,
+            kind: 'polygon',
+            html: '▰'
+        }
+    });
+
+    // extend the control to draw rectangles
+    L.NewRectangleControl = L.EditControl.extend({
+        options: {
+            position: 'topleft',
+            callback: map.editTools.startRectangle,
+            kind: 'rectangle',
+            html: '⬛'
+        }
+    });
+
+    // add the two new controls to the map
+    map.addControl(new L.NewPolygonControl());
+    map.addControl(new L.NewRectangleControl());
+
+    // when users CMD/CTRL click an editable feature, remove it from the map and delete it from the service
+    pedestrianDistricts.on('click', function (e) {
+      if ((e.originalEvent.ctrlKey || e.originalEvent.metaKey) && e.layer.editEnabled()) {
+        e.layer.editor.deleteShapeAt(e.latlng);
+        // delete expects an id, not the whole geojson object
+        pedestrianDistricts.deleteFeature(e.layer.feature.id);
+      }
+    });
+
+    // when users double click a graphic toggle its editable status
+    // when deselecting, pass the geometry update to the service
+    pedestrianDistricts.on('dblclick', function (e) {
+      e.layer.toggleEdit();
+      if (!e.layer.editEnabled()) {
+        pedestrianDistricts.updateFeature(e.layer.toGeoJSON());
+      }
+    });
+
+    // when a new feature is drawn using one of the custom controls, pass the edit to the service
+    map.on('editable:drawing:commit', function (e) {
+      pedestrianDistricts.addFeature(e.layer.toGeoJSON());
+      e.layer.toggleEdit();
+    });
+</script>

--- a/src/pages/examples/editing.hbs
+++ b/src/pages/examples/editing.hbs
@@ -2,6 +2,7 @@
 title: Editing feature layers
 description: This sample uses <a href="//github.com/Leaflet/Leaflet.draw">Leaflet Draw</a> to help edit the geometry of features in a hosted feature service.
 layout: example.hbs
+legacy: true
 ---
 
 <!-- Leaflet Draw -->

--- a/src/partials/header.hbs
+++ b/src/partials/header.hbs
@@ -43,8 +43,13 @@
     <script src="/js/linked/leaflet-dist/leaflet-src.js"></script>
     <script src="/js/linked/esri-leaflet-dist/esri-leaflet-debug.js"></script>
   {{else}}
+    {{#if page.data.legacy}}
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet-src.js"></script>
+    {{else}}
     <link rel="stylesheet" href="https://unpkg.com/leaflet@{{package.sample-versions.leaflet}}/dist/leaflet.css" />
     <script src="https://unpkg.com/leaflet@{{package.sample-versions.leaflet}}/dist/leaflet-src.js"></script>
+    {{/if}}
     <script src="https://unpkg.com/esri-leaflet@{{package.sample-versions.esri-leaflet}}"></script>
   {{/if}}
 

--- a/src/partials/sidebar-examples.hbs
+++ b/src/partials/sidebar-examples.hbs
@@ -23,7 +23,7 @@
     <a href="{{assets}}examples/zooming-to-all-features-2.html">Zoom to all Features #2</a>
     <a href="{{assets}}examples/labeling-features.html">Labeling Features</a>
     <a href="{{assets}}examples/layer-ordering.html">Ordering Layers</a>
-    <!--a href="{{assets}}examples/editing.html">Editing</a-->
+    <a href="{{assets}}examples/editable.html">Editing</a>
   </nav>
 
   <h5>Feature Layer Plugins</h5>


### PR DESCRIPTION
i finally got around to testing out [Leaflet.Editable](https://github.com/Leaflet/Leaflet.Editable) and it makes for a significantly more straightforward feature service editing demo than piggybacking off [Leaflet.Draw](https://github.com/Leaflet/Leaflet.Draw).

i'm taking the old sample out of the sidebar to make it less findable, but not removing it entirely. _neither_ of two plugins support Leaflet v1.1.0 yet, so i added a flag to ensure that they both load v1.0.3 for the time being.

ref: https://github.com/Esri/esri-leaflet/issues/684