### PR TITLE
add persistent link to terms and conditions in footer of all pages

### DIFF
--- a/src/partials/copyright.hbs
+++ b/src/partials/copyright.hbs
@@ -1,3 +1,3 @@
-<div class="container centered-text">
+<div class="container center-text">
   <p class="copyright">Esri Leaflet is a project from the <a href="http://pdx.esri.com">Esri PDX R&amp;D Center</a> and the <a href="https://github.com/Esri/esri-leaflet/graphs/contributors">Esri Community</a></p>
 </div>

--- a/src/partials/footer.hbs
+++ b/src/partials/footer.hbs
@@ -1,3 +1,5 @@
+  <div class="container center-text">
+    <p class="copyright"><a href="https://github.com/esri/esri-leaflet#terms">Terms</a></p>
   </div>
   <script src="{{assets}}js/script.js"></script>
   </body>

--- a/src/scss/base/_layout.scss
+++ b/src/scss/base/_layout.scss
@@ -46,11 +46,10 @@ body {
 .copyright {
   display: inline-block;
   font-size: 1rem;
-  color: $white;
-  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
+  color: black;
   margin: 0;
   a {
-    color: $white;
+    color: black;
     &:hover {
       border-color: $white;
     }


### PR DESCRIPTION
* center existing 'made by' text (on pages with markdown)
* white > black
* add centered [Terms](https://github.com/esri/esri-leaflet#terms) link on all pages as a footer