### PR TITLE
add reference to renderers plugin for feature layers

### DIFF
--- a/src/pages/api-reference/layers/feature-layer.md
+++ b/src/pages/api-reference/layers/feature-layer.md
@@ -27,6 +27,8 @@ You can create a new empty feature service with a single layer on the [ArcGIS fo
 
 `L.esri.FeatureLayer` divides the current map extent into a grid of individual cells and uses them to fire queries to fetch nearby features. This technique is comparable to [MODE_ONDEMAND](https://developers.arcgis.com/javascript/3/jshelp/best_practices_feature_layers.html) in the ArcGIS API for JavaScript.
 
+When adding a layer to the map using `L.esri.FeatureLayer`, the features will use the default Leaflet symbology.  If you want the layer to use the symbology defined in the Map or Feature Service, you need to use the [Esri Leaflet Renderers](https://github.com/Esri/esri-leaflet-renderers) plugin.  There are [limitations](https://github.com/Esri/esri-leaflet-renderers#limitations) for this plugin, so please consider those.
+
 ### Constructor
 
 <table>

--- a/src/pages/api-reference/layers/feature-layer.md
+++ b/src/pages/api-reference/layers/feature-layer.md
@@ -27,7 +27,7 @@ You can create a new empty feature service with a single layer on the [ArcGIS fo
 
 `L.esri.FeatureLayer` divides the current map extent into a grid of individual cells and uses them to fire queries to fetch nearby features. This technique is comparable to [MODE_ONDEMAND](https://developers.arcgis.com/javascript/3/jshelp/best_practices_feature_layers.html) in the ArcGIS API for JavaScript.
 
-When adding a layer to the map using `L.esri.FeatureLayer`, the features will use the default Leaflet symbology.  If you want the layer to use the symbology defined in the Map or Feature Service, you need to use the [Esri Leaflet Renderers](https://github.com/Esri/esri-leaflet-renderers) plugin.  There are [limitations](https://github.com/Esri/esri-leaflet-renderers#limitations) for this plugin, so please consider those.
+If you want your `FeatureLayer` to display the symbology defined in the map or feature service, you need to use the [Esri Leaflet Renderers](https://github.com/Esri/esri-leaflet-renderers) plugin.
 
 ### Constructor
 

--- a/src/pages/examples/simple-feature-layer.hbs
+++ b/src/pages/examples/simple-feature-layer.hbs
@@ -1,6 +1,8 @@
 ---
 title: Simple FeatureLayer
 description: Display a feature layer from ArcGIS Online or ArcGIS server. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.FeatureLayer</a> documentation.
+
+If you want the features to retain the symbology from the published Map or Feature Service, you must use the <a href="https://github.com/Esri/esri-leaflet-renderers">Esri Leaflet Renderers</a> plugin.
 layout: example.hbs
 ---
 

--- a/src/pages/examples/simple-feature-layer.hbs
+++ b/src/pages/examples/simple-feature-layer.hbs
@@ -1,8 +1,6 @@
 ---
 title: Simple FeatureLayer
 description: Display a feature layer from ArcGIS Online or ArcGIS server. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.FeatureLayer</a> documentation.
-
-If you want the features to retain the symbology from the published Map or Feature Service, you must use the <a href="https://github.com/Esri/esri-leaflet-renderers">Esri Leaflet Renderers</a> plugin.
 layout: example.hbs
 ---
 
@@ -12,6 +10,8 @@ layout: example.hbs
   var map = L.map('map').setView([45.526, -122.667], 13);
 
   L.esri.basemapLayer('Streets').addTo(map);
+
+  // a Leaflet marker is used by default to symbolize point features.
   L.esri.featureLayer({
     url: 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0'
   }).addTo(map);


### PR DESCRIPTION
Here's a simple attempt to make clear the relationship between the feature layer constructor and the renderers plugin in regards to symbology.