### PR TITLE
add more details for server response formats

### DIFF
--- a/src/pages/api-reference/layers/dynamic-map-layer.md
+++ b/src/pages/api-reference/layers/dynamic-map-layer.md
@@ -41,7 +41,7 @@ Option | Type | Default | Description
 `url` | `String` | | *Required* URL of the [Map Service](http://resources.arcgis.com/en/help/arcgis-rest-api/#/Map_Service/02r3000000w2000000/).
 `format` | `String` | `'png24'` | Output format of the image.
 `transparent` | `Boolean` | `true` | Allow the server to produce transparent images.
-`f` | `String` | `'json'` |  Server response content type. Can also be `image`.  See the [REST API](https://developers.arcgis.com/rest/services-reference/map-service.htm) for more information.
+`f` | `String` | `'json'` |  Server response content type [`"json"` &#124; `"image"`](https://developers.arcgis.com/rest/services-reference/export-map.htm).
 `attribution` | `String` |  |  Attribution from service metadata [copyright text](https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer) is automatically displayed in Leaflet's default control.  This property can be used for customization.
 `layers` | `Array` |  | An array of Layer IDs like `[3,4,5]` to show from the service.
 `layerDefs` | `Object` |  | SQL filters to define what features will be included in the image rendered by the service. An object is used with keys that map each query to its respective layer. <br> `{ 3: "STATE_NAME='Kansas'", 9: "POP2007>25000" }`

--- a/src/pages/api-reference/layers/dynamic-map-layer.md
+++ b/src/pages/api-reference/layers/dynamic-map-layer.md
@@ -41,7 +41,7 @@ Option | Type | Default | Description
 `url` | `String` | | *Required* URL of the [Map Service](http://resources.arcgis.com/en/help/arcgis-rest-api/#/Map_Service/02r3000000w2000000/).
 `format` | `String` | `'png24'` | Output format of the image.
 `transparent` | `Boolean` | `true` | Allow the server to produce transparent images.
-`f` | `String` | `'json'` |  Server response content type.
+`f` | `String` | `'json'` |  Server response content type. Can also be `image`.  See the [REST API](https://developers.arcgis.com/rest/services-reference/map-service.htm) for more information.
 `attribution` | `String` |  |  Attribution from service metadata [copyright text](https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer) is automatically displayed in Leaflet's default control.  This property can be used for customization.
 `layers` | `Array` |  | An array of Layer IDs like `[3,4,5]` to show from the service.
 `layerDefs` | `Object` |  | SQL filters to define what features will be included in the image rendered by the service. An object is used with keys that map each query to its respective layer. <br> `{ 3: "STATE_NAME='Kansas'", 9: "POP2007>25000" }`

--- a/src/pages/api-reference/layers/image-map-layer.md
+++ b/src/pages/api-reference/layers/image-map-layer.md
@@ -36,7 +36,7 @@ Option | Type | Default | Description
 --- | --- | --- | ---
 `url` | `String` | | *Required* URL of the [Image Service](http://resources.arcgis.com/en/help/arcgis-rest-api/#/Image_Service/02r3000000q8000000/).
 `format` | `String` | `'jpegpng'` | Output format of the image.
-`f` | `String` | `'image'` | Server response content type.
+`f` | `String` | `'image'` | Server response content type. Can also be `json`.  See the [REST API](https://developers.arcgis.com/rest/services-reference/image-service.htm) for more information.
 `opacity` | `Number` | `1` | Opacity of the layer. Should be a value between 0 and 1.
 `position` | `String` | `'front'` | Position of the layer relative to other overlays.
 `maxZoom` | `Number` | | Closest zoom level the layer will be displayed on the map.

--- a/src/pages/api-reference/layers/image-map-layer.md
+++ b/src/pages/api-reference/layers/image-map-layer.md
@@ -36,7 +36,7 @@ Option | Type | Default | Description
 --- | --- | --- | ---
 `url` | `String` | | *Required* URL of the [Image Service](http://resources.arcgis.com/en/help/arcgis-rest-api/#/Image_Service/02r3000000q8000000/).
 `format` | `String` | `'jpegpng'` | Output format of the image.
-`f` | `String` | `'image'` | Server response content type. Can also be `json`.  See the [REST API](https://developers.arcgis.com/rest/services-reference/image-service.htm) for more information.
+`f` | `String` | `'image'` | Server response content type [`"json"` &#124; `"image"`](https://developers.arcgis.com/rest/services-reference/export-image.htm).
 `opacity` | `Number` | `1` | Opacity of the layer. Should be a value between 0 and 1.
 `position` | `String` | `'front'` | Position of the layer relative to other overlays.
 `maxZoom` | `Number` | | Closest zoom level the layer will be displayed on the map.

--- a/src/pages/api-reference/layers/raster-layer.md
+++ b/src/pages/api-reference/layers/raster-layer.md
@@ -13,7 +13,7 @@ A generic class representing an image layer. This class can be extended to provi
 
 Option | Type | Default | Description
 --- | --- | --- | ---
-`f` | `String` | `'image'` |  Server response content type. Can also be `json`.
+`f` | `String` | `'image'` |  Server response content type `"json"` &#124; `"image"`.
 `opacity` | `Number` | `1` | Opacity of the layer. Should be a value between 0 and 1.
 `position` | `String` | `'front'` | Position of the layer relative to other overlays.
 `maxZoom` | `Number` | | Closest zoom level the layer will be displayed on the map.

--- a/src/pages/api-reference/layers/raster-layer.md
+++ b/src/pages/api-reference/layers/raster-layer.md
@@ -13,7 +13,7 @@ A generic class representing an image layer. This class can be extended to provi
 
 Option | Type | Default | Description
 --- | --- | --- | ---
-`f` | `String` | `'image'` |  Server response content type.
+`f` | `String` | `'image'` |  Server response content type. Can also be `json`.
 `opacity` | `Number` | `1` | Opacity of the layer. Should be a value between 0 and 1.
 `position` | `String` | `'front'` | Position of the layer relative to other overlays.
 `maxZoom` | `Number` | | Closest zoom level the layer will be displayed on the map.


### PR DESCRIPTION
Added a second option for `f`, as well as link to REST API docs.  I didn't include other options like HTML and KMZ because I wasn't sure if it made sense.  But I am more than happy to include all valid formats per REST API docs if desired.