### PR TITLE
First imageMapLayer sample needs useCors: false.

### DIFF
--- a/src/pages/api-reference/layers/image-map-layer.md
+++ b/src/pages/api-reference/layers/image-map-layer.md
@@ -230,7 +230,9 @@ var url = "https://sampleserver3.arcgisonline.com/ArcGIS/rest/services/World/MOD
 
 L.esri.imageMapLayer({
   url: url,
-  opacity : 0.25
+  opacity : 0.25,
+  // only necessary for old versions of ArcGIS Server
+  useCors: false
 }).addTo(map);
 
 ```


### PR DESCRIPTION
HT, @jgravois!

The Blue Marble MODIS example in the doc won't work unless CORS is disabled.

Resolves https://github.com/Esri/esri-leaflet/issues/1128.