### PR TITLE
Vector basemaps api update

### DIFF
--- a/src/pages/api-reference/layers/vector-basemap.md
+++ b/src/pages/api-reference/layers/vector-basemap.md
@@ -31,25 +31,24 @@ Extends [`L.Layer`](http://leafletjs.com/reference-{{siteData.latest_leaflet}}.h
 
 Worldwide coverage at a variety of zoom levels.
 
-* `Streets`
-* `StreetsNight`
-* `StreetsRelief`
-* `Navigation`
-* `DarkGray`
-* `Gray`
-* `Topographic`
-* `Hybrid`
 * `OpenStreetMap` (added in `2.0.0`)
+* `Streets`
+* `StreetsRelief`
+* `StreetsNight`
+* `Topographic`
+* `Navigation`
+* `Gray` (no labels)
+* `DarkGray` (no labels)
 * `Nova`
+* `Hybrid`
 * `ChartedTerritory` (added in `2.0.2`)
 * `ColoredPencil`
 * `Newspaper` (added in `1.0.2`)
 * `MidCentury` (added in `1.0.2`)
-* `Spring` (added in `1.0.2`)
-* `HumanGeography`
-* `HumanGeographyDetail`
-* `DarkHumanGeography`
-* `DarkHumanGeographyDetail` (added in `2.0.2`)
+* `HumanGeography` (no labels)
+* `HumanGeographyDetail` (no labels)
+* `DarkHumanGeography` (no labels)
+* `DarkHumanGeographyDetail` (no labels; added in `2.0.2`)
 
 ### Options
 

--- a/src/pages/api-reference/layers/vector-basemap.md
+++ b/src/pages/api-reference/layers/vector-basemap.md
@@ -31,16 +31,25 @@ Extends [`L.Layer`](http://leafletjs.com/reference-{{siteData.latest_leaflet}}.h
 
 Worldwide coverage at a variety of zoom levels.
 
-* `Newspaper` (added in `1.0.2`)
-* `MidCentury` (added in `1.0.2`)
-* `Spring` (added in `1.0.2`)
-* `Gray`
-* `DarkGray`
-* `Topographic`
-* `Navigation`
 * `Streets`
 * `StreetsNight`
 * `StreetsRelief`
+* `Navigation`
+* `DarkGray`
+* `Gray`
+* `Topographic`
+* `Hybrid`
+* `OpenStreetMap` (added in `2.0.0`)
+* `Nova`
+* `ChartedTerritory` (added in `2.0.2`)
+* `ColoredPencil`
+* `Newspaper` (added in `1.0.2`)
+* `MidCentury` (added in `1.0.2`)
+* `Spring` (added in `1.0.2`)
+* `HumanGeography`
+* `HumanGeographyDetail`
+* `DarkHumanGeography`
+* `DarkHumanGeographyDetail` (added in `2.0.2`)
 
 ### Options
 


### PR DESCRIPTION
- Add in Vector Basemap plugin keys for all available basemaps.
- Remove reference to "Spring" (I don't see it listed as an option; but at one point it was)
- I'm including reference to new basemaps that will be in a future release (I'm fine with modifying my PR and removing those references)