### PR TITLE
by default all layers are identified, not just the one on top

### DIFF
--- a/src/pages/api-reference/tasks/identify-features.md
+++ b/src/pages/api-reference/tasks/identify-features.md
@@ -71,7 +71,7 @@ Extends [`L.esri.Task`]({{assets}}api-reference/tasks/task.html)
             <td><code>layers({{{param 'String' 'layers'}}})</code></td>
             <td><code>this</code></td>
             <td>
-              By default, only the topmost feature will be identified, but it is possible to specify both an alternative strategy and array of individual layers.  See the REST API [documentation](http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Identify_Map_Service/02r300000113000000/) for more information about valid combinations.<br>
+              By default, all features will be identified, but it is possible to specify both an alternative strategy and array of individual layers.  See the REST API [documentation](http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Identify_Map_Service/02r300000113000000/) for more information about valid combinations.<br>
               ex: `.layers('all:0')`.
             </td>
         </tr>


### PR DESCRIPTION
https://gis.stackexchange.com/questions/311590/esri-leaflet-identify-only-on-added-layer-from-mapservice/311624#311624