### PR TITLE
Load esri-leaflet-renderers.js via HTTPS

### DIFF
--- a/src/pages/examples/webmap.hbs
+++ b/src/pages/examples/webmap.hbs
@@ -14,7 +14,7 @@ layout: example.hbs
 <script src="https://cdn.jsdelivr.net/leaflet.esri.heatmap-feature-layer/2.0.0-beta.1/esri-leaflet-heatmap-feature-layer.js"></script>
 
  <!-- Load Esri Leaflet Renderers from CDN -->
- <script src="http://cdn.jsdelivr.net/leaflet.esri.renderers/2.0.2/esri-leaflet-renderers.js"></script>
+ <script src="https://cdn.jsdelivr.net/leaflet.esri.renderers/2.0.2/esri-leaflet-renderers.js"></script>
 
  <!-- Load Vector Icon from GitHub -->
  <script src="https://muxlab.github.io/Leaflet.VectorIcon/L.VectorIcon.js"></script>


### PR DESCRIPTION
The request is blocked and throwing errors on the example page.

Changing to https should fix the example.