### PR TITLE
243-active-page-css

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -39,3 +39,23 @@ document.addEventListener(touchEvent, function (e) {
   var menu = document.querySelector('#site-nav-wrapper'); // Using a class instead, see note below.
   menu.classList.toggle('show');
 }, false);
+
+// attempt to style the active page's corresponding top site nav link
+var headerActiveLinkElement = document.querySelector(`.site-nav-wrapper a[href*="${window.location.pathname.split('/')[1]}"]`);
+if (headerActiveLinkElement) {
+  headerActiveLinkElement.style.borderBottom = '2px solid #FFFFFF';
+}
+
+// attempt to style the active page's corresponding sidebar link
+var sidebarActiveLinkElement = document.querySelector(`.sidebar a[href$="${window.location.pathname}"]`);
+if (sidebarActiveLinkElement) {
+  sidebarActiveLinkElement.style.borderBottom = '2px solid #79BD8F';
+  sidebarActiveLinkElement.style.fontWeight = 'bold';
+}
+
+// attempt to style the active page's corresponding sidebar link in the mobile menu
+var mobileMenuActiveLinkElement = document.querySelector(`.mobile-menu .sidebar a[href$="${window.location.pathname}"]`);
+if (mobileMenuActiveLinkElement) {
+  mobileMenuActiveLinkElement.style.borderBottom = '2px solid #79BD8F';
+  mobileMenuActiveLinkElement.style.fontWeight = 'bold';
+}

--- a/src/partials/sidebar-tutorials.hbs
+++ b/src/partials/sidebar-tutorials.hbs
@@ -1,9 +1,9 @@
 <aside class="sidebar">
   <h5>General</h5>
   <nav>
-    <a href="create-your-first-app.html">Create your First App</a>
-    <a href="introduction-to-layer-types.html">Introduction to Layer Types</a>
-    <a href="working-with-feature-layers.html">Working with Feature Layers</a>
-    <a href="working-with-authenticated-services-server.html">Working with Authenticated Services</a>
+    <a href="{{assets}}tutorials/create-your-first-app.html">Create Your First App</a>
+    <a href="{{assets}}tutorials/introduction-to-layer-types.html">Introduction to Layer Types</a>
+    <a href="{{assets}}tutorials/working-with-feature-layers.html">Working with Feature Layers</a>
+    <a href="{{assets}}tutorials/working-with-authenticated-services-server.html">Working with Authenticated Services</a>
   </nav>
 </aside>


### PR DESCRIPTION
Resolves #243.

Changes:
- The active page's corresponding links get extra styling in 3 locations: the sidebar menu, mobile sidebar menu (at the bottom of the document when the browser is narrow), and in the topmost site nav links.
- Bottom border styles should match the already established `:hover` styling.