### PR TITLE
added link to "layer types" documentation

### DIFF
--- a/src/pages/api-reference/index.hbs
+++ b/src/pages/api-reference/index.hbs
@@ -7,7 +7,7 @@ layout: documentation.hbs
 
 ### Layers
 
-`Layers` provide visualization capabilities for data hosted in Feature Services, Map Services and Image Services.
+`Layers` provide visualization capabilities for data hosted in Feature Services, Map Services and Image Services. See [Introduction to Layer Types]({{assets}}tutorials/introduction-to-layer-types.html) for more information on when to use which type.
 
 * [`L.esri.BasemapLayer`]({{assets}}api-reference/layers/basemap-layer.html)
 * [`L.esri.DynamicMapLayer`]({{assets}}api-reference/layers/dynamic-map-layer.html)


### PR DESCRIPTION
adds a link to "layer types" documentation for convenience, per request in https://github.com/Esri/esri-leaflet/issues/1104

![image](https://user-images.githubusercontent.com/209355/88567573-36358300-d027-11ea-814c-6837bdfe14a0.png)

closes https://github.com/Esri/esri-leaflet/issues/1104