### PR TITLE
Geosearch Control Text Additions

### DIFF
--- a/src/pages/api-reference/controls/geosearch.md
+++ b/src/pages/api-reference/controls/geosearch.md
@@ -98,6 +98,19 @@ For reference here is the internal DOM structure of the geocoder
   </ul>
 </div>
 ```
+
+By default, ellipses are shown when the text of suggestions is too long.  However, you may want to show the entire suggestions text.
+
+The following `CSS` rule will show the entire suggestions text, broken onto multiple lines.  You will need to add the rule in your own custom stylesheet associated with your project:
+
+```css
+.geocoder-control-suggestions .geocoder-control-suggestion {
+    overflow-wrap: break-word;
+    word-break: break-all;
+    overflow: visible;
+    white-space: break-spaces;
+  }
+```
 ### Providers
 
 The `Geosearch` control can also search for results from a variety of sources including Feature Layers and Map Services. This is done with plain text matching and is not "real" geocoding. But it allows you to mix custom results into a search box.

--- a/src/pages/api-reference/controls/geosearch.md
+++ b/src/pages/api-reference/controls/geosearch.md
@@ -105,11 +105,11 @@ The following `CSS` rule will show the entire suggestions text, broken onto mult
 
 ```css
 .geocoder-control-suggestions .geocoder-control-suggestion {
-    overflow-wrap: break-word;
-    word-break: break-all;
-    overflow: visible;
-    white-space: break-spaces;
-  }
+  overflow-wrap: break-word;
+  word-break: break-all;
+  overflow: visible;
+  white-space: break-spaces;
+}
 ```
 ### Providers
 


### PR DESCRIPTION
add helper text and code example on how to show entire suggestions text from geosearch control.

related to esri/esri-leaflet-geocoder#264.