### PR TITLE
support api keys in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ working
 built/
 
 .vscode
+
+**/secret.json

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -78,7 +78,7 @@ module.exports = function (grunt) {
       },
       dist: {
         options: {
-          data: ['data/siteData.json', 'package.json'],
+          data: ['data/secret.json', 'data/siteData.json', 'package.json'],
           assets: 'built/'
         },
         files: [{

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 1. clone this repository
 2. `npm install -g grunt-cli`
 3. `npm install`
+4. Create a new file, `data/secret.json` to include an API Key:
+   ```
+   {
+     "api_key": "YOUR API KEY HERE"
+   }
+   ```
 4. `npm start`
 
 In order to update the version of Leaflet, Esri Leaflet or any other plugin displayed in the documentation site:

--- a/src/layouts/example.hbs
+++ b/src/layouts/example.hbs
@@ -10,6 +10,7 @@ layout: page.hbs
   <p>{{{ description }}}</p>
 </div>
 <div id="map-wrapper">
+  <script>const apiKey = "{{secret.api_key}}";</script>
   {{> body }}
 </div>
 {{#markdown}}

--- a/src/pages/examples/geocoding-control.hbs
+++ b/src/pages/examples/geocoding-control.hbs
@@ -14,7 +14,19 @@ geocoder: true
     attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
   }).addTo(map);
 
-  var searchControl = L.esri.Geocoding.geosearch().addTo(map);
+
+  var searchControl = L.esri.Geocoding.geosearch({
+    position: "topright",
+    placeholder: "Enter an address or place e.g. 1 York St",
+    useMapBounds: false,
+    providers: [L.esri.Geocoding.arcgisOnlineProvider({
+      apikey: apiKey, // replace with your api key - https://developers.arcgis.com
+      nearby: {
+        lat: -33.8688,
+        lng: 151.2093
+      },
+    })]
+  }).addTo(map);
 
   var results = L.layerGroup().addTo(map);
 


### PR DESCRIPTION
adds instructions on how to create `data/secret.json` and makes the "geocoding control" page work.