### PR TITLE
Adding react-esri-leaflet plugin to plugins page

### DIFF
--- a/src/pages/plugins/index.hbs
+++ b/src/pages/plugins/index.hbs
@@ -155,6 +155,18 @@ class: plugins
     </div>
 
     <div class="card">
+      <h3><a href="https://github.com/slutske22/react-esri-leaflet">React-Esri-Leaflet</a></h3>
+      <p>
+        React-leaflet wrapper for esri-leaflet.
+      </p>
+      <iframe src="https://ghbtns.com/github-btn.html?user=slutske22&repo=react-esri-leaflet&type=fork&count=true"
+        frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+      <br>
+      <iframe src="https://ghbtns.com/github-btn.html?user=slutske22&repo=react-esri-leaflet&type=star&count=true"
+        frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+    </div>
+
+    <div class="card">
       <h3><a href="https://github.com/jgravois/esri-leaflet-related">Related Records</a></h3>
       <p>
         Plugin to assist in querying ArcGIS Services for related records.


### PR DESCRIPTION
I made a plugin for esri-leaflet - [react-esri-leaflet](https://github.com/slutske22/react-esri-leaflet).  I'm pretty proud of it.  I just finished updating it to be compatible with the new v3.  Let me know if you think its worthy of joining the group of community plugins on the plugins page!