### PR TITLE
sampleserver3 fixes

### DIFF
--- a/src/pages/examples/identifying-imagery.hbs
+++ b/src/pages/examples/identifying-imagery.hbs
@@ -32,10 +32,10 @@ layout: example.hbs
   // sample server in this example is not CORS enabled, so use JSONP
   L.esri.get = L.esri.get.JSONP;
 
-  var map = L.map('map').setView([36.230577, -118.253147], 10);
+  var map = L.map('map').setView([34.314417, -117.461712], 12);
 
   var hillshade = L.esri.imageMapLayer({
-    url: 'https://sampleserver3.arcgisonline.com/ArcGIS/rest/services/Earthquakes/CaliforniaDEM/ImageServer',
+    url: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/Elevation/MtBaldy_Elevation/ImageServer',
     renderingRule: renderingRule,
     useCors: false
   }).addTo(map);

--- a/src/pages/examples/image-map-layer-mosaic-rule.hbs
+++ b/src/pages/examples/image-map-layer-mosaic-rule.hbs
@@ -1,6 +1,6 @@
 ---
 title: ImageMapLayer MosaicRule
-description: Display an Image Service from ArcGIS Online or ArcGIS Server and apply a mosaic rule to dynamically control how the service combines rasters into a mosaic. This sample shows world temperature using the 8th raster only (August of 1950). More information about Image Services can be found in the <a href="/esri-leaflet/api-reference/layers/image-map-layer.html">L.esri.ImageMapLayer</a> documentation.
+description: Display an Image Service from ArcGIS Online or ArcGIS Server and apply a mosaic rule to dynamically control how the service combines rasters into a mosaic. This sample shows sea temperature at the surface for the week of April 7, 2014. More information about Image Services can be found in the <a href="/esri-leaflet/api-reference/layers/image-map-layer.html">L.esri.ImageMapLayer</a> documentation.
 layout: example.hbs
 ---
 
@@ -8,14 +8,26 @@ layout: example.hbs
 
 <script>
   var mosaicRule = {
-    mosaicMethod: 'esriMosaicLockRaster',
-    lockRasterIds: [8]
+    multidimensionalDefinition: [
+      {
+        // DEPTH: show only temperatures at sea surface
+        dimensionName: 'StdZ', // water depth
+        values: [0], // sea surface or 0ft
+        isSlice: true
+      },
+      {
+        // TIME: only show temperatures for the week of April 7, 2014
+        dimensionName: 'StdTime', // time temp was recorded
+        values: [1396828800000], // week of April 7, 2014
+        isSlice: true
+      }
+    ]
   };
 
   var map = L.map('map').setView([30, 0], 2);
 
   L.esri.imageMapLayer({
-    url: 'https://sampleserver3.arcgisonline.com/ArcGIS/rest/services/World/Temperature/ImageServer',
+    url: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/ScientificData/SeaTemperature/ImageServer',
     mosaicRule: mosaicRule,
     useCors: false
   }).addTo(map);

--- a/src/pages/examples/image-map-layer-rendering-rule.hbs
+++ b/src/pages/examples/image-map-layer-rendering-rule.hbs
@@ -9,8 +9,8 @@ vector: true
 
 <script>
   var renderingRule = {
-    rasterFunction: "TorontoFalseColor",
-    variableName: "Raster"
+    rasterFunction: 'TorontoFalseColor',
+    variableName: 'Raster'
   };
 
   var map = L.map('map').setView([43.645262, -79.38], 14);

--- a/src/pages/examples/image-map-layer-rendering-rule.hbs
+++ b/src/pages/examples/image-map-layer-rendering-rule.hbs
@@ -9,23 +9,18 @@ vector: true
 
 <script>
   var renderingRule = {
-    rasterFunction: 'Hillshade',
-    rasterFunctionArguments: {
-      Azimuth: 215,
-      Altitude: 60,
-      ZFactor: 1
-    },
-    variableName: 'DEM'
+    rasterFunction: "TorontoFalseColor",
+    variableName: "Raster"
   };
 
-  var map = L.map('map').setView([33.741114, -116.184826], 17);
+  var map = L.map('map').setView([43.645262, -79.38], 14);
 
   L.esri.Vector.vectorBasemapLayer('ArcGIS:Imagery', {
     apikey: apiKey // Replace with your API key - https://developers.arcgis.com
   }).addTo(map);
 
   L.esri.imageMapLayer({
-    url: 'https://sampleserver3.arcgisonline.com/ArcGIS/rest/services/Earthquakes/SanAndreasLidar/ImageServer',
+    url: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/Toronto/ImageServer',
     renderingRule: renderingRule,
     useCors: false
   }).addTo(map);

--- a/src/pages/examples/imagery-popups.hbs
+++ b/src/pages/examples/imagery-popups.hbs
@@ -8,14 +8,14 @@ vector: true
 <div id="map"></div>
 
 <script>
-  var map = L.map('map').setView([45.358651, -121.691067], 9);
+  var map = L.map('map').setView([43.645262, -79.38], 14);
 
   L.esri.Vector.vectorBasemapLayer('ArcGIS:LightGray', {
     apikey: apiKey // Replace with your API key - https://developers.arcgis.com
   }).addTo(map);
 
   var landsatImagery = L.esri.imageMapLayer({
-    url: 'https://sampleserver3.arcgisonline.com/ArcGIS/rest/services/Portland/CascadeLandsat/ImageServer',
+    url: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/Toronto/ImageServer',
     useCors: false
   }).addTo(map);
 

--- a/src/pages/examples/visualizing-time-on-dynamic-map-layer.hbs
+++ b/src/pages/examples/visualizing-time-on-dynamic-map-layer.hbs
@@ -1,6 +1,6 @@
 ---
 title: Time Ranges
-description: Using time to filter visualized information from a Map Service. Enter dates between 1930 and 1980. More information about Map Services can be found in the <a href="../api-reference/layers/dynamic-map-layer.html">L.esri.DynamicMapLayer</a> documentation.
+description: Using time to filter visualized information from a Map Service. Enter dates between 1970 and 2009. More information about Map Services can be found in the <a href="../api-reference/layers/dynamic-map-layer.html">L.esri.DynamicMapLayer</a> documentation.
 layout: example.hbs
 vector: true
 ---
@@ -38,11 +38,11 @@ vector: true
   <form action="#" id="form">
     <label for="from">
       From
-      <input id="from" type="date" value="1930-01-01" name="from">
+      <input id="from" type="date" value="1970-01-01" name="from">
     </label>
     <label for="to">
       To
-      <input  id="to" type="date" value="1950-12-31" name="to">
+      <input  id="to" type="date" value="1973-12-31" name="to">
     </label>
     <input type="submit" value="Update">
   </form>
@@ -53,14 +53,14 @@ vector: true
   var startTimeInput = document.getElementById('from');
   var endTimeInput = document.getElementById('to');
 
-  var map = L.map('map').setView([37.604, -101.15], 9);
+  var map = L.map('map').setView([39, -96], 3);
 
   L.esri.Vector.vectorBasemapLayer('ArcGIS:LightGray', {
     apikey: apiKey // Replace with your API key - https://developers.arcgis.com
   }).addTo(map);
 
   var oilWells = L.esri.dynamicMapLayer({
-    url: 'https://sampleserver3.arcgisonline.com/ArcGIS/rest/services/Petroleum/KSWells/MapServer',
+    url: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/Earthquakes_Since1970/MapServer',
     useCors: false,
     layers: [0],
     // for some reason this service in particular sometimes redirects json requests to a bogus IP address


### PR DESCRIPTION
Since sampleserver3 appears to be down, this switches the applicable samples to use equivalent services on sampleserver6.

The only example that is still using sampleserver3 is `\examples\image-map-layer-mosaic-rule.hbs` - @jwasilgeo is there a layer you can find that would be good for this?