### PR TITLE
Redirect pages to developers.arcgis.com

### DIFF
--- a/src/pages/api-reference/controls/geosearch.md
+++ b/src/pages/api-reference/controls/geosearch.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/controls/geosearch/
 title: L.esri.Geocoding.Geosearch
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/events.md
+++ b/src/pages/api-reference/events.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/events/
 title: Events
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/index.hbs
+++ b/src/pages/api-reference/index.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/
 title: API Reference
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/layers/basemap-layer.md
+++ b/src/pages/api-reference/layers/basemap-layer.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/layers/basemap-layer/
 title: L.esri.BasemapLayer (Deprecated)
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/layers/cluster-feature-layer.md
+++ b/src/pages/api-reference/layers/cluster-feature-layer.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/layers/cluster-feature-layer/
 title: L.esri.Cluster.FeatureLayer
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/layers/dynamic-map-layer.md
+++ b/src/pages/api-reference/layers/dynamic-map-layer.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/layers/dynamic-map-layer/
 title: L.esri.DynamicMapLayer
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/layers/feature-layer.md
+++ b/src/pages/api-reference/layers/feature-layer.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/layers/feature-layer/
 title: L.esri.FeatureLayer
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/layers/heatmap-feature-layer.md
+++ b/src/pages/api-reference/layers/heatmap-feature-layer.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/layers/heatmap-feature-layer/
 title: L.esri.Heat.FeatureLayer
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/layers/image-map-layer.md
+++ b/src/pages/api-reference/layers/image-map-layer.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/layers/image-map-layer/
 title: L.esri.ImageMapLayer
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/layers/raster-layer.md
+++ b/src/pages/api-reference/layers/raster-layer.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/layers/raster-layer/
 title: L.esri.RasterLayer
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/layers/tiled-map-layer.md
+++ b/src/pages/api-reference/layers/tiled-map-layer.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/layers/tiled-map-layer/
 title: L.esri.TiledMapLayer
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/layers/vector-basemap.md
+++ b/src/pages/api-reference/layers/vector-basemap.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/layers/vector-basemap/
 title: L.esri.Vector.vectorBasemapLayer
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/layers/vector-layer.md
+++ b/src/pages/api-reference/layers/vector-layer.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/layers/vector-layer/
 title: L.esri.Vector.vectorTileLayer
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/options.md
+++ b/src/pages/api-reference/options.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/options/
 title: options
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/request.md
+++ b/src/pages/api-reference/request.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/request/
 title: request
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/services/feature-layer-service.md
+++ b/src/pages/api-reference/services/feature-layer-service.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/services/feature-layer-service/
 title: L.esri.FeatureLayerService
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/services/geocode-service.md
+++ b/src/pages/api-reference/services/geocode-service.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/services/geocode-service/
 title: L.esri.Geocoding.GeocodeService
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/services/gp-service.md
+++ b/src/pages/api-reference/services/gp-service.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/services/gp-service/
 title: L.esri.GP.Service
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/services/image-service.md
+++ b/src/pages/api-reference/services/image-service.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/services/image-service/
 title: L.esri.ImageService
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/services/map-service.md
+++ b/src/pages/api-reference/services/map-service.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/services/map-service/
 title: L.esri.MapService
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/services/service.md
+++ b/src/pages/api-reference/services/service.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/services/service/
 title: L.esri.Service
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/tasks/find.md
+++ b/src/pages/api-reference/tasks/find.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/tasks/find/
 title: L.esri.Find
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/tasks/geocode.md
+++ b/src/pages/api-reference/tasks/geocode.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/tasks/geocode/
 title: L.esri.Geocoding.Geocode
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/tasks/gp.md
+++ b/src/pages/api-reference/tasks/gp.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/tasks/gp/
 title: L.esri.GP.Task
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/tasks/identify-features.md
+++ b/src/pages/api-reference/tasks/identify-features.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/tasks/identify-features/
 title: L.esri.IdentifyFeatures
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/tasks/identify-image.md
+++ b/src/pages/api-reference/tasks/identify-image.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/tasks/identify-image/
 title: L.esri.IdentifyImage
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/tasks/query-related.md
+++ b/src/pages/api-reference/tasks/query-related.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/tasks/query-related/
 title: L.esri.Related.Query
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/tasks/query.md
+++ b/src/pages/api-reference/tasks/query.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/tasks/query/
 title: L.esri.Query
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/tasks/reverse-geocode.md
+++ b/src/pages/api-reference/tasks/reverse-geocode.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/tasks/reverse-geocode/
 title: L.esri.Geocoding.ReverseGeocode
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/tasks/suggest.md
+++ b/src/pages/api-reference/tasks/suggest.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/tasks/suggest/
 title: L.esri.Geocoding.Suggest
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/tasks/task.md
+++ b/src/pages/api-reference/tasks/task.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/tasks/task/
 title: L.esri.Task
 layout: documentation.hbs
 ---

--- a/src/pages/api-reference/util.md
+++ b/src/pages/api-reference/util.md
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/api-reference/util/
 title: Utilities
 layout: documentation.hbs
 ---

--- a/src/pages/download/index.md
+++ b/src/pages/download/index.md
@@ -2,6 +2,7 @@
 title: Download
 layout: markdown.hbs
 class: no-sidebar
+redirect: https://developers.arcgis.com/esri-leaflet/install-and-setup/
 ---
 
 # Download

--- a/src/pages/examples/arcgis-online-auth.hbs
+++ b/src/pages/examples/arcgis-online-auth.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/arcgis-online-auth/
 title: ArcGIS Online OAuth
 description: Allow ArcGIS Online users to sign in with OAuth 2.0 to access their own information, private resources and premium services. Esri's <a href='https://github.com/esri/esri-leaflet#terms'>Terms of Use</a> require that appropriate attribution be displayed.
 layout: example.hbs

--- a/src/pages/examples/arcgis-server-auth.hbs
+++ b/src/pages/examples/arcgis-server-auth.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/arcgis-server-auth/
 title: ArcGIS Server username/password
 description: Example showing authentication with ArcGIS Server via a username and password. In this example a username and password are hardcoded in.
 layout: example.hbs

--- a/src/pages/examples/basemap-with-labels.hbs
+++ b/src/pages/examples/basemap-with-labels.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/basemap-with-labels/
 title: Basemap with labels
 description: Use the "ArcGIS:Imagery" basemap key to get Imagery with Labels. A full list of basemap keys can be found <a href="https://developers.arcgis.com/documentation/mapping-apis-and-services/maps/services/basemap-layer-service/#default-basemap-styles">here</a>.
 layout: example.hbs

--- a/src/pages/examples/cedar-chart.hbs
+++ b/src/pages/examples/cedar-chart.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/cedar-chart/
 title: Dynamic feature charting with Cedar
 description: Plot feature attributes on a dynamic chart that updates as users pan and zoom. This demo relies on <a href="https://github.com/Esri/cedar">Esri Cedar</a> to render an interactive scatterplot.
 layout: example.hbs

--- a/src/pages/examples/center-map-on-address.hbs
+++ b/src/pages/examples/center-map-on-address.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/center-map-on-address/
 title: Center the map
 description: Geocode an address and then center the map on it automatically. This demo relies of the <a href="https://github.com/Esri/esri-leaflet-geocoder">Esri Leaflet Geocoder</a> plugin.
 layout: example.hbs

--- a/src/pages/examples/clustering-feature-layers.hbs
+++ b/src/pages/examples/clustering-feature-layers.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/clustering-feature-layers/
 title: Clustering points
 description: Visualize dense services as clusters of points with the <a href="https://github.com/Leaflet/Leaflet.markercluster">L.markercluster</a> plugin. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.FeatureLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/composing-basemaps.hbs
+++ b/src/pages/examples/composing-basemaps.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/composing-basemaps/
 title: Composing Basemaps
 description: This sample shows how to add two separate layers - one imagery and one label layer. In practice, common combinations are available directly, for example, use "ArcGIS:Imagery" for Imagery with Labels. A full list of basemap keys can be found <a href="https://developers.arcgis.com/documentation/mapping-apis-and-services/maps/services/basemap-layer-service/#default-basemap-styles">here</a>.
 layout: example.hbs

--- a/src/pages/examples/customizing-popups.hbs
+++ b/src/pages/examples/customizing-popups.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/customizing-popups/
 title: Custom Popup with Dynamic Map Layer
 description: Customizing a popup on a Dynamic Map Layer. Click to render a popup. More information about Map Services can be found in the <a href="../api-reference/layers/dynamic-map-layer.html">L.esri.DynamicMapLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/dynamic-chart.hbs
+++ b/src/pages/examples/dynamic-chart.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/dynamic-chart/
 title: Dynamic feature charting with Chart.js
 description: Plot feature attributes on a dynamic chart that updates as users pan and zoom, and respond to chart interactions by modifying feature layer contents. This demo relies on <a href="https://www.chartjs.org/">Chart.js</a> to render an interactive scatterplot.
 layout: example.hbs

--- a/src/pages/examples/editable.hbs
+++ b/src/pages/examples/editable.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/editable/
 title: Editing feature layers
 description: This sample uses the Leaflet <a href="https://github.com/Leaflet/Leaflet.Editable">Editable plugin</a> (coupled with the <a href="https://github.com/w8r/Leaflet.Path.Drag">Leaflet.Path.Drag plugin</a>) to help users manipulate the geometry of features from a hosted feature service and pass the edits back to the server.
 layout: example.hbs

--- a/src/pages/examples/feature-layer-popups.hbs
+++ b/src/pages/examples/feature-layer-popups.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/feature-layer-popups/
 title: Custom popups
 description: Customize popups on a Feature Layer. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.FeatureLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/feature-layer-snapshot.hbs
+++ b/src/pages/examples/feature-layer-snapshot.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/feature-layer-snapshot/
 title: Load each and every feature initially
 description: Sometimes it is desirable to load a "snapshot" of a Feature Layer instead of loading it progressively as you pan around the map. The approach is useful for smaller services.
 layout: example.hbs

--- a/src/pages/examples/geocoding-control.hbs
+++ b/src/pages/examples/geocoding-control.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/geocoding-control/
 title: Geocoding control
 description: Using the geocoding control to search for addresses and center the map. This demo relies on the <a href="https://github.com/Esri/esri-leaflet-geocoder">Esri Leaflet Geocoder</a> plugin.
 layout: example.hbs

--- a/src/pages/examples/getting-service-metadata.hbs
+++ b/src/pages/examples/getting-service-metadata.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/getting-service-metadata/
 title: Getting service metadata
 description: Retrieving service metadata such as name, bounding box and capabilities. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.FeatureLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/gp-plugin.hbs
+++ b/src/pages/examples/gp-plugin.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/gp-plugin/
 title: Leverage a Geoprocessing Service
 description: This demo relies on the <a href="https://github.com/jgravois/esri-leaflet-gp/">Esri Leaflet GP</a> plugin.<br>More information about Geoprocessing Services can be found in the <a href="https://developers.arcgis.com/rest/services-reference/gp-service.htm">ArcGIS REST</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/identifying-features.hbs
+++ b/src/pages/examples/identifying-features.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/identifying-features/
 title: Identifying Features
 description: Identifying features on a Dynamic Map Layer on click by querying the service. Click a feature to identify it. More information about Map Services can be found in the <a href="../api-reference/layers/dynamic-map-layer.html">L.esri.DynamicMapLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/identifying-imagery.hbs
+++ b/src/pages/examples/identifying-imagery.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/identifying-imagery/
 title: Identifying Imagery
 description: Display an Image Service from ArcGIS Online or ArcGIS Server and get the pixel value at a specific location. This sample displays a digital elevation model (DEM) for the state of California rendered with a hillshade (see <a href="/esri-leaflet/examples/image-map-layer-rendering-rule.html">ImageMapLayer RenderingRule sample</a>). Clicking on map returns the raw DEM value for that location (elevation in meters). More information about Image Services can be found in the <a href="/esri-leaflet/api-reference/tasks/identify-image.html">L.esri.IdentifyImage</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/image-map-layer-mosaic-rule.hbs
+++ b/src/pages/examples/image-map-layer-mosaic-rule.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/image-map-layer-mosaic-rule/
 title: ImageMapLayer MosaicRule
 description: Display an Image Service from ArcGIS Online or ArcGIS Server and apply a mosaic rule to dynamically control how the service combines rasters into a mosaic. This sample shows sea temperature at the surface for the week of April 7, 2014. More information about Image Services can be found in the <a href="/esri-leaflet/api-reference/layers/image-map-layer.html">L.esri.ImageMapLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/image-map-layer-rendering-rule.hbs
+++ b/src/pages/examples/image-map-layer-rendering-rule.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/image-map-layer-rendering-rule/
 title: ImageMapLayer RenderingRule
 description: Display an Image Service from ArcGIS Online or ArcGIS Server and apply a rendering rule to dynamically modify the display of the raster dataset. Rendering rules are created using a pre-defined set of <a href="https://developers.arcgis.com/documentation/common-data-types/raster-function-objects.htm">raster functions</a> contained in the ArcGIS Server 10 REST API. This example shows a raster image generated from raw LIDAR (Light Detection and Ranging) data rendered with a hillshade. More information about Image Services can be found in the <a href="/esri-leaflet/api-reference/layers/image-map-layer.html">L.esri.ImageMapLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/imagery-popups.hbs
+++ b/src/pages/examples/imagery-popups.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/imagery-popups/
 title: Custom Popup with Image Map Layer
 description: Customizing a popup on a Image Map Layer. Click to render a popup. More information about Image Services can be found in the <a href="/esri-leaflet/api-reference/layers/image-map-layer.html">L.esri.ImageMapLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/index.hbs
+++ b/src/pages/examples/index.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/showing-a-basemap/
 title: Esri Leaflet Quickstart
 description: This is a simple Esri Leaflet application. Notice that the map attribution updates automatically as users pan and zoom in accordance with Esri's <a href='https://github.com/esri/esri-leaflet#terms'>Terms of Use</a>. For additional explanation, see <a href="https://developers.arcgis.com/esri-leaflet/maps/display-a-map/">the tutorial</a>.
 layout: example.hbs

--- a/src/pages/examples/labeling-features.hbs
+++ b/src/pages/examples/labeling-features.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/labeling-features/
 title: Labeling Features
 description: This demo shows how to add static text labels to the center of features. <strong>This is not the same as fitting labels dynamically</strong>, so labels will start to collide as you zoom out.
 layout: example.hbs

--- a/src/pages/examples/layer-ordering.hbs
+++ b/src/pages/examples/layer-ordering.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/layer-ordering/
 title: Ordering Feature Layers
 description: Controlling the order of feature layers allows greater cartographic control over the rendering of layers beyond the normal tile / polygon / point ordering.
 layout: example.hbs

--- a/src/pages/examples/layers-control.hbs
+++ b/src/pages/examples/layers-control.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/layers-control/
 title: Leaflet Control.Layers
 description: This sample demonstrates how to pass ArcGIS Services to Leaflet's native <a href="https://leafletjs.com/reference.html#control-layers">Control.Layers</a> which allows users to switch between different base layers and switch overlays on/off.
 layout: example.hbs

--- a/src/pages/examples/non-mercator-projection-2.hbs
+++ b/src/pages/examples/non-mercator-projection-2.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/non-mercator-projection-2/
 title: Non-mercator projection
 description: Using non mercator tiles with <code>L.esri.TiledMapLayer</code> with the <a href="https://github.com/kartena/Proj4Leaflet">Proj4Leaflet</a> plugin. <br><br> <strong>This demo should be implemented at your own risk. Esri Leaflet only supports tiles that have been published in Web Mercator Auxiliary Sphere tiling scheme (WKID 102100/3857). Strong knowledge of projections, spatial references and tiling schemes is required for this.</strong>
 layout: example.hbs

--- a/src/pages/examples/non-mercator-projection.hbs
+++ b/src/pages/examples/non-mercator-projection.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/non-mercator-projection/
 title: Non-mercator projection
 description: Using non mercator tiles with <code>L.esri.TiledMapLayer</code> with the <a href="https://github.com/kartena/Proj4Leaflet">Proj4Leaflet</a> plugin. <br><br> <strong>This demo should be implemented at your own risk. Esri Leaflet only supports tiles that have been published in Web Mercator Auxiliary Sphere tiling scheme (WKID 102100/3857). Strong knowledge of projections, spatial references and tiling schemes is required for this.</strong>
 layout: example.hbs

--- a/src/pages/examples/parse-feature-collection.hbs
+++ b/src/pages/examples/parse-feature-collection.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/parse-feature-collection/
 title: Feature Collection Parsing
 description: Parse a feature collection contained in a webmap to GeoJSON.
 layout: example.hbs

--- a/src/pages/examples/premium-content.hbs
+++ b/src/pages/examples/premium-content.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/premium-content/
 title: Access premium ArcGIS Online content
 description: Access Esri hosted and curated content is ArcGIS Online like traffic maps. You will be asked to authenticate with ArcGIS Online, alternately in your application you can generate a token and pass it in.
 layout: example.hbs

--- a/src/pages/examples/query-no-map.hbs
+++ b/src/pages/examples/query-no-map.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/query-no-map/
 title: Query without a map
 description: It is not necessary to add a layer to a map in order to execute a spatial query. More information about Queries can be found in the <a href="../api-reference/tasks/query.html">L.esri.Query</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/querying-feature-layers-1.hbs
+++ b/src/pages/examples/querying-feature-layers-1.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/querying-feature-layers-1/
 title: Querying features
 description: Configuring a query to filter features on a <code>L.esri.FeatureLayer</code>. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.FeatureLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/querying-feature-layers-2.hbs
+++ b/src/pages/examples/querying-feature-layers-2.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/querying-feature-layers-2/
 title: Querying features
 description: Performing advanced queries on a Feature Layer. Click on the map to query for features within 250 meters. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.FeatureLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/renderers-plugin.hbs
+++ b/src/pages/examples/renderers-plugin.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/renderers-plugin/
 title: Inherit service symbology
 description: This sample demonstrates how to recreate the symbology defined for feature services in the client automatically.  The demo relies on the <a href="https://github.com/Esri/esri-leaflet-renderers/">Esri Leaflet Renderers</a> plugin.
 layout: example.hbs

--- a/src/pages/examples/retina-basemap.hbs
+++ b/src/pages/examples/retina-basemap.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/retina-basemap/
 title: Retina Basemap
 description: Displaying basemaps at higher resolutions on retina devices with the <code>detectRetina</code> option. In this example the base layer is added at retina resolutions and the labels are added at regular resolutions.
 layout: example.hbs

--- a/src/pages/examples/reverse-geocoding.hbs
+++ b/src/pages/examples/reverse-geocoding.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/reverse-geocoding/
 title: Reverse geocoding
 description: Query the closest address to a given point with the Esri Leaflet Geocoder plugin. Click to show the closest street address to the clicked point. This demo relies on the <a href="https://github.com/Esri/esri-leaflet-geocoder">Esri Leaflet Geocoder</a> plugin.
 layout: example.hbs

--- a/src/pages/examples/search-feature-layer-search-mode.hbs
+++ b/src/pages/examples/search-feature-layer-search-mode.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/search-feature-layer-search-mode/
 title: Search modes for searching within feature layers
 description: Searches features layers for matching text in addition to geocoding. This demo relies on the <a href="https://github.com/Esri/esri-leaflet-geocoder">Esri Leaflet Geocoder</a> plugin.
 layout: example.hbs

--- a/src/pages/examples/search-feature-layer.hbs
+++ b/src/pages/examples/search-feature-layer.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/search-feature-layer/
 title: Searching feature layers
 description: Searches features layers for matching text in addition to geocoding. This demo relies on the <a href="https://github.com/Esri/esri-leaflet-geocoder">Esri Leaflet Geocoder</a> plugin.
 layout: example.hbs

--- a/src/pages/examples/search-map-service.hbs
+++ b/src/pages/examples/search-map-service.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/search-map-service/
 title: Searching map services
 description: In addition to geocoding addresses and points of interest, you can also search features in map services for matching text. This demo relies on the <a href="https://github.com/Esri/esri-leaflet-geocoder">Esri Leaflet Geocoder</a> plugin.
 layout: example.hbs

--- a/src/pages/examples/showing-a-basemap.hbs
+++ b/src/pages/examples/showing-a-basemap.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/showing-a-basemap/
 title: Showing an ArcGIS basemap
 description: Display an ArcGIS Online basemap using the <a href="../api-reference/layers/vector-basemap.html">Esri Leaflet Vector plugin</a>. Notice that the map attribution updates automatically as users pan and zoom in accordance with Esri's <a href='https://github.com/esri/esri-leaflet#terms'>Terms of Use</a>.
 layout: example.hbs

--- a/src/pages/examples/simple-dynamic-map-layer.hbs
+++ b/src/pages/examples/simple-dynamic-map-layer.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/simple-dynamic-map-layer/
 title: Simple DynamicMapLayer
 description: Display a Map Service from ArcGIS Online or ArcGIS Server.  If the service is published in a different coordinate system than the map, it will reproject on the fly automatically.  More information about Map Services can be found in the <a href="../api-reference/layers/dynamic-map-layer.html">L.esri.DynamicMapLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/simple-editing.hbs
+++ b/src/pages/examples/simple-editing.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/
 title: Editing feature layers
 description: This sample demonstrates a bare-bones approach for passing edits to a feature service.
 layout: example.hbs

--- a/src/pages/examples/simple-feature-layer.hbs
+++ b/src/pages/examples/simple-feature-layer.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/simple-feature-layer/
 title: Simple FeatureLayer
 description: Display a feature layer from ArcGIS Online or ArcGIS server. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.FeatureLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/simple-image-map-layer.hbs
+++ b/src/pages/examples/simple-image-map-layer.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/simple-image-map-layer/
 title: Simple ImageMapLayer
 description: Display an Image Service from ArcGIS Online or ArcGIS Server.  More information about Map Services can be found in the <a href="/esri-leaflet/api-reference/layers/image-map-layer.html">L.esri.ImageMapLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/simplifying-complex-features.hbs
+++ b/src/pages/examples/simplifying-complex-features.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/simplifying-complex-features/
 title: Simplifying complex features
 description: Complex features can be simplified on the server for faster response times. Zoom in and watch as higher resolution vectors are loaded from the service. Hover over features for effects. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.FeatureLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/spatial-queries.hbs
+++ b/src/pages/examples/spatial-queries.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/spatial-queries/
 title: Spatial Queries on a Feature Layer
 description: Create detailed spatial queries like point within polygon or line intersects polygons with Feature Layer queries. Some combinations will not result in any features being highlighted.
 layout: example.hbs

--- a/src/pages/examples/stream-plugin.hbs
+++ b/src/pages/examples/stream-plugin.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/stream-plugin/
 title: Add a Stream Service
 description: This demo displays a real-time data feed from a service published using the <a href="https://server.arcgis.com/en/geoevent-extension/latest/process-event-data/stream-services.htm">GeoEvent extension</a> for ArcGIS Server using a <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API">WebSocket</a>.  In addition to Esri Leaflet, it relies on <a href="https://github.com/rowanwins/esri-leaflet-stream">Esri Leaflet Stream.</a>
 layout: example.hbs

--- a/src/pages/examples/styling-clusters.hbs
+++ b/src/pages/examples/styling-clusters.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/styling-clusters/
 title: Styling clusters
 description: Customizing the display of clusters and markers with <code>L.DivIcon</code> and <code>L.MarkerClusterGroup</code> options. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.FeatureLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/styling-feature-layer-points.hbs
+++ b/src/pages/examples/styling-feature-layer-points.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/styling-feature-layer-points/
 title: Styling points
 description: Custom styles on point features with <code>L.Icon</code>. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.FeatureLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/styling-feature-layer-polygons.hbs
+++ b/src/pages/examples/styling-feature-layer-polygons.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/styling-feature-layer-polygons/
 title: Styling polygons
 description: Custom styling of polygons with the <code>style</code> option. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.FeatureLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/styling-feature-layer-polylines.hbs
+++ b/src/pages/examples/styling-feature-layer-polylines.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/styling-feature-layer-polylines/
 title: Styling lines
 description: Custom styles for line features with the <code>style</code> option. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.FeatureLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/styling-heatmaps.hbs
+++ b/src/pages/examples/styling-heatmaps.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/styling-heatmaps/
 title: Styling heatmaps
 description: Custom styling of heatmap gradients with the <code>L.heat</code> options. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.FeatureLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/switching-basemaps.hbs
+++ b/src/pages/examples/switching-basemaps.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/switching-basemaps/
 title: Switching basemaps
 description: Switching between all available basemaps packaged with Esri Leaflet. For additional explanation, see <a href="https://developers.arcgis.com/esri-leaflet/maps/change-the-basemap-layer/">the tutorial</a>.
 layout: example.hbs

--- a/src/pages/examples/tile-layer-1.hbs
+++ b/src/pages/examples/tile-layer-1.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/tile-layer-1/
 title: Historic Topographic Maps
 description: Displaying tiles hosted on ArcGIS Online.
 layout: example.hbs

--- a/src/pages/examples/tile-layer-2.hbs
+++ b/src/pages/examples/tile-layer-2.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/tile-layer-2/
 title: Navigation Charts
 description: Displaying custom tilesets hosted on ArcGIS Online.
 layout: example.hbs

--- a/src/pages/examples/turf.hbs
+++ b/src/pages/examples/turf.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/turf/
 title: Use Turf and Esri Leaflet together
 description: Esri Leaflet pairs nicely with clientside libraries that can perform spatial analysis in the browser like <a href="https://turfjs.org/getting-started/">Turf.js</a>. This demo shows how the output from a spatial query can be augmented to isolate features that have a spatial relationship with another arbitrary geometry.
 layout: example.hbs

--- a/src/pages/examples/visualize-points-as-a-heatmap.hbs
+++ b/src/pages/examples/visualize-points-as-a-heatmap.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/visualize-points-as-a-heatmap/
 title: Points as a heatmap
 description: Displaying point data as a heatmap using the <code>L.heat</code> plugin. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.FeatureLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/visualizing-time-on-dynamic-map-layer.hbs
+++ b/src/pages/examples/visualizing-time-on-dynamic-map-layer.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/visualizing-time-on-dynamic-map-layer/
 title: Time Ranges
 description: Using time to filter visualized information from a Map Service. Enter dates between 1970 and 2009. More information about Map Services can be found in the <a href="../api-reference/layers/dynamic-map-layer.html">L.esri.DynamicMapLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/visualizing-time-on-image-layer.hbs
+++ b/src/pages/examples/visualizing-time-on-image-layer.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/visualizing-time-on-image-layer/
 title: Time Ranges
 description: Select a snapshot between 1990 and 2010 to fetch Landsat bands; 4,3,2. More information about ImageMapLayers can be found in the <a href="../api-reference/layers/image-map-layer.html">L.esri.ImageMapLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/visualizing-time-with-feature-layer.hbs
+++ b/src/pages/examples/visualizing-time-with-feature-layer.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/visualizing-time-on-dynamic-map-layer/
 title: Visualizing time on a feature layer
 description: Filtering a feature layer within a certain time range. Try dates between January 3, 1998, and January 25, 1998. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.FeatureLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/webmap.hbs
+++ b/src/pages/examples/webmap.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/webmap/
 title: Displaying Web maps
 description: With the appropriate plugins, its possible to render web maps created in arcgis.com.
 layout: example.hbs

--- a/src/pages/examples/zooming-to-all-features-1.hbs
+++ b/src/pages/examples/zooming-to-all-features-1.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/zooming-to-all-features-1/
 title: Zoom to all features
 description: Fitting the map to the boundaries of all features in the layer by querying the service. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.FeatureLayer</a> documentation.
 layout: example.hbs

--- a/src/pages/examples/zooming-to-all-features-2.hbs
+++ b/src/pages/examples/zooming-to-all-features-2.hbs
@@ -1,4 +1,5 @@
 ---
+redirect: https://developers.arcgis.com/esri-leaflet/samples/zooming-to-all-features-2/
 title: Zoom to all features #2
 description: This sample creates a latLngBounds object clientside which contains the geometries fetched from the server.  An approach like this is necessary when working with older Feature Services (prior to ArcGIS Server 10.3.1) that don't support making direct requests to the server for the 'bounds' of features matching a query.
 layout: example.hbs

--- a/src/pages/index.hbs
+++ b/src/pages/index.hbs
@@ -1,5 +1,6 @@
 ---
 class: homepage
+redirect: https://developers.arcgis.com/esri-leaflet/
 ---
 
 <div class="homepage-copy">

--- a/src/pages/plugins/index.hbs
+++ b/src/pages/plugins/index.hbs
@@ -1,5 +1,6 @@
 ---
 class: plugins
+redirect: https://developers.arcgis.com/esri-leaflet/plugins/
 ---
 
 <div class="container">

--- a/src/pages/tutorials/display-a-map.md
+++ b/src/pages/tutorials/display-a-map.md
@@ -2,6 +2,7 @@
 title: Display a map
 description: Learn how to display an ArcGIS Online basemap in Leaflet.
 layout: tutorials.hbs
+redirect: https://developers.arcgis.com/esri-leaflet/maps/display-a-map/
 ---
 
 # {{ page.data.title }}

--- a/src/pages/tutorials/index.md
+++ b/src/pages/tutorials/index.md
@@ -2,10 +2,11 @@
 title: Tutorials
 description: How-to guides for using Esri Leaflet.
 layout: tutorials.hbs
+redirect: https://developers.arcgis.com/esri-leaflet/tutorials/
 ---
 
 # {{ page.data.title }}
 
-Please start with [Display a map](display-a-map.html). 
+Please start with [Display a map](display-a-map.html).
 
 For using Esri Leaflet with the latest JavaScript frameworks, see [JavaScript Libraries](javascript-libraries.html).

--- a/src/pages/tutorials/introduction-to-layer-types.md
+++ b/src/pages/tutorials/introduction-to-layer-types.md
@@ -2,6 +2,7 @@
 title: Introduction to Layer Types
 description: Learn how to differentiate between the layer types that make up the ArcGIS platform.
 layout: tutorials.hbs
+redirect: https://developers.arcgis.com/esri-leaflet/layers/
 ---
 
 # {{ page.data.title }}

--- a/src/pages/tutorials/javascript-libraries.md
+++ b/src/pages/tutorials/javascript-libraries.md
@@ -2,6 +2,7 @@
 title: JavaScript Libraries
 description: How to use Esri Leaflet with modern JavaScript libraries and frameworks.
 layout: tutorials.hbs
+redirect: https://developers.arcgis.com/esri-leaflet/
 ---
 
 # {{ page.data.title }}

--- a/src/pages/tutorials/working-with-authenticated-services-server.md
+++ b/src/pages/tutorials/working-with-authenticated-services-server.md
@@ -2,6 +2,7 @@
 title: Working with Authenticated Services in ArcGIS Server
 description: How to access secure ArcGIS Enterprise services in Esri Leaflet.
 layout: tutorials.hbs
+redirect: https://developers.arcgis.com/esri-leaflet/authentication/apikeys/
 ---
 
 # {{ page.data.title }}

--- a/src/partials/header.hbs
+++ b/src/partials/header.hbs
@@ -19,6 +19,10 @@
     <meta name="description" content="A lightweight set of tools for using ArcGIS services with Leaflet.">
   {{/if}}
 
+  {{#if page.data.redirect}}
+    <meta http-equiv="refresh" content="0;URL='{{page.data.redirect}}'" />
+  {{/if}}
+
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <!--[if lt IE 9]>


### PR DESCRIPTION
This change adds a redirect to the pages, to [help search engines like Google](https://developers.google.com/search/docs/crawling-indexing/301-redirects#metarefresh) update results to point to the latest updated documentation.